### PR TITLE
feat: Integrate OpenRouter into LLMService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,13 @@
-# OpenRouter API Key
-OPENROUTER_API_KEY=""
+# LLM Provider: "openai" or "openrouter"
+LLM_PROVIDER="openai"
+
+# -- OpenAI Configuration --
+OPENAI_API_KEY="your_openai_api_key_here"
+OPENAI_MODEL="gpt-4-turbo"
+
+# -- OpenRouter Configuration --
+# Get API key from https://openrouter.ai/keys
+OPENROUTER_API_KEY="your_openrouter_api_key_here"
+# Kimi (Moonshot) model identifier
+OPENROUTER_MODEL="moonshot/moonshot-v1-128k"
+OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,22 @@
+# System Memory & Design Log
+
+This document records significant architectural decisions, refactorings, and learnings encountered during development.
+
+---
+
+### 2025-08-20: Flexible LLM Service Integration
+
+**Context:**
+The initial `LLMService` was tightly coupled to the OpenAI API. Task 2 required integrating OpenRouter to allow for a wider variety of models, such as `kimi-2` (Moonshot).
+
+**Decision:**
+The `LLMService` was refactored to support both OpenAI and any OpenAI-compatible API (like OpenRouter) via environment variables. This was achieved with minimal code changes by reusing the `openai` Python client, which can be configured with a custom `base_url`.
+
+**Implementation:**
+- **`.env` Configuration:** Introduced `LLM_PROVIDER` ("openai" or "openrouter") to select the active service. Added provider-specific variables for API keys, model names, and base URLs (`OPENROUTER_*`, `OPENAI_*`).
+- **`LLMService.__init__`:** The constructor now reads `LLM_PROVIDER` and conditionally configures the `openai.OpenAI` client with the appropriate `api_key` and `base_url`.
+- **Testing:** The test suite for `LLMService` was updated to mock `python-dotenv.load_dotenv` to prevent `.env` files from interfering with tests that rely on a clean environment. Tests were parameterized to cover both OpenAI and OpenRouter configurations.
+
+**Learning:**
+- A `load_dotenv()` call within a class constructor can lead to non-obvious test failures. When tests need to manipulate environment variables, the `load_dotenv` call itself should be mocked to ensure the test environment is properly isolated.
+- The `openai` library's support for a custom `base_url` is a powerful feature for abstracting away the specific backend provider with very little effort, perfectly aligning with a "minimal LOC" philosophy.

--- a/self_improving_quant/services/llm_service.py
+++ b/self_improving_quant/services/llm_service.py
@@ -1,0 +1,84 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import openai
+from dotenv import load_dotenv
+
+__all__ = ["LLMService"]
+
+
+class LLMService:
+    """
+    A service to interact with a Large Language Model.
+    It can be configured to use either OpenAI or an OpenRouter-compatible API.
+    """
+
+    # impure: Loads .env, reads environment variables
+    def __init__(self) -> None:
+        """Initializes the LLM service client based on environment variables."""
+        load_dotenv()
+        provider = os.getenv("LLM_PROVIDER", "openai").lower()
+
+        api_key: Optional[str]
+        base_url: Optional[str] = None
+        model: Optional[str]
+
+        if provider == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY")
+            base_url = os.getenv("OPENROUTER_BASE_URL")
+            model = os.getenv("OPENROUTER_MODEL")
+        elif provider == "openai":
+            api_key = os.getenv("OPENAI_API_KEY")
+            model = os.getenv("OPENAI_MODEL")
+        else:
+            raise ValueError(f"Unsupported LLM_PROVIDER: '{provider}'. Must be 'openai' or 'openrouter'.")
+
+        if not api_key:
+            raise ValueError(f"API key for provider '{provider}' not found. Set {provider.upper()}_API_KEY.")
+        if not model:
+            raise ValueError(f"Model for provider '{provider}' not found. Set {provider.upper()}_MODEL.")
+
+        self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+        self.model = model
+        self.provider = provider
+
+    # impure: Performs network I/O to an LLM API
+    def get_strategy_suggestion(self, history: List[Dict[str, Any]]) -> str:
+        """
+        Gets a strategy suggestion from the configured LLM.
+
+        Args:
+            history: A list of previous reports to provide as context.
+
+        Returns:
+            The raw JSON string response from the LLM.
+        """
+        # In a real implementation, this would load and format a prompt from `prompts/`
+        prompt = "Based on the following history, suggest a new trading strategy:\n" + str(history)
+
+        # Per H-28, log cost-related info. Using print as logger isn't available here.
+        print(f"INFO: Calling LLM. Provider: {self.provider}, Model: {self.model}")
+
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": "You are a quantitative analyst. Respond with JSON."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.7,
+        )
+
+        # Per H-28, log token usage.
+        if completion.usage:
+            print(
+                f"INFO: LLM call successful. Tokens: "
+                f"Prompt={completion.usage.prompt_tokens}, "
+                f"Completion={completion.usage.completion_tokens}"
+            )
+
+        response = completion.choices[0].message.content
+        if not response:
+            # Per H-12, avoid silent failures.
+            raise ValueError("LLM returned an empty response.")
+
+        return response

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,91 @@
+import os
+import sys
+from unittest import mock
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
+
+# Ensure the source code is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from self_improving_quant.services.llm_service import LLMService
+
+# A minimal, reusable mock for the openai.ChatCompletion object
+MOCK_COMPLETION = ChatCompletion(
+    id="chatcmpl-123",
+    choices=[
+        Choice(
+            finish_reason="stop",
+            index=0,
+            message=ChatCompletionMessage(content='{"strategy": "mock"}', role="assistant", tool_calls=None),
+        )
+    ],
+    created=1677652288,
+    model="mock_model",
+    object="chat.completion",
+    usage=CompletionUsage(completion_tokens=10, prompt_tokens=5, total_tokens=15),
+)
+
+@pytest.mark.parametrize(
+    "provider, env_vars, expected_api_key, expected_base_url, expected_model",
+    [
+        (
+            "openai",
+            {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "openai_key", "OPENAI_MODEL": "gpt-4"},
+            "openai_key", None, "gpt-4"
+        ),
+        (
+            "openrouter",
+            {
+                "LLM_PROVIDER": "openrouter",
+                "OPENROUTER_API_KEY": "openrouter_key",
+                "OPENROUTER_MODEL": "kimi-2",
+                "OPENROUTER_BASE_URL": "https://router.ai/api",
+            },
+            "openrouter_key", "https://router.ai/api", "kimi-2"
+        ),
+    ],
+)
+@mock.patch("self_improving_quant.services.llm_service.load_dotenv")
+@mock.patch("self_improving_quant.services.llm_service.openai.OpenAI")
+def test_llm_service_initialization(
+    mock_openai_client, mock_load_dotenv, provider, env_vars, expected_api_key, expected_base_url, expected_model
+):
+    """Tests that LLMService initializes the client correctly for each provider."""
+    with mock.patch.dict(os.environ, env_vars, clear=True):
+        service = LLMService()
+        mock_openai_client.assert_called_once_with(api_key=expected_api_key, base_url=expected_base_url)
+        assert service.provider == provider
+        assert service.model == expected_model
+
+@pytest.mark.parametrize(
+    "provider, env_vars, expected_error_msg",
+    [
+        ("openai", {"LLM_PROVIDER": "openai", "OPENAI_MODEL": "gpt-4"}, "API key for provider 'openai' not found"),
+        ("openai", {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "key"}, "Model for provider 'openai' not found"),
+        ("openrouter", {"LLM_PROVIDER": "openrouter", "OPENROUTER_API_KEY": "key"}, "Model for provider 'openrouter' not found"),
+    ]
+)
+@mock.patch("self_improving_quant.services.llm_service.load_dotenv")
+def test_llm_service_missing_env_vars_raises_error(mock_load_dotenv, provider, env_vars, expected_error_msg):
+    """Tests that LLMService raises ValueError if required env vars are missing."""
+    with mock.patch.dict(os.environ, env_vars, clear=True):
+        with pytest.raises(ValueError) as excinfo:
+            LLMService()
+        assert expected_error_msg in str(excinfo.value)
+
+@mock.patch("self_improving_quant.services.llm_service.load_dotenv")
+@mock.patch("self_improving_quant.services.llm_service.openai.OpenAI")
+def test_get_strategy_suggestion_calls_client(mock_openai_client, mock_load_dotenv):
+    """Tests the suggestion method calls the client and returns the expected response."""
+    mock_instance = mock_openai_client.return_value
+    mock_instance.chat.completions.create.return_value = MOCK_COMPLETION
+
+    env_vars = {"LLM_PROVIDER": "openai", "OPENAI_API_KEY": "key", "OPENAI_MODEL": "model"}
+    with mock.patch.dict(os.environ, env_vars, clear=True):
+        service = LLMService()
+        response = service.get_strategy_suggestion(history=[{"some": "history"}])
+
+        mock_instance.chat.completions.create.assert_called_once()
+        assert response == '{"strategy": "mock"}'


### PR DESCRIPTION
Refactors `LLMService` to support both OpenAI and OpenRouter as configurable LLM providers. The selection is controlled by the `LLM_PROVIDER` environment variable.

This change allows the system to use a wider variety of models, such as `moonshot/moonshot-v1-128k` (Kimi), by pointing the `openai` client to the OpenRouter base URL.

Key changes:
- Added `LLM_PROVIDER`, `OPENROUTER_*` variables to `.env.example`.
- `LLMService` now conditionally configures the client based on the provider.
- Added parameterized tests to cover both provider configurations.
- Patched `load_dotenv` in tests to ensure environment isolation.
- Documented the changes and learnings in `docs/memory.md`.

Net LOC delta: +200
Rationale: Adds required flexibility to the LLM service. The new test file and documentation contribute to the line count but are necessary for quality and maintainability.