### PR TITLE
feat(llm): Implement LLMService and stabilize environment

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -143,7 +143,7 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   The interface bug is fixed and verified with an integration test.
 *   **Time estimate:** 1.5 hours
-*   **Status:** Not Started
+*   **Status:** Completed
 
 ---
 
@@ -158,7 +158,7 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   All type errors are resolved.
 *   **Time estimate:** 1 hour
-*   **Status:** Not Started
+*   **Status:** Completed
 
 ---
 
@@ -174,7 +174,7 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   All placeholder files are deleted and `main.py` is refactored.
 *   **Time estimate:** 1 hour
-*   **Status:** Not Started
+*   **Status:** Completed
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ where = ["src"]
 
 [tool.mypy]
 python_version = "3.12"
-packages = ["src"]
+packages = ["src", "tests"]
 strict = true
 
 [[tool.mypy.overrides]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core application libraries
 pandas
+numpy<2.0 # Pinned for pandas-ta compatibility
 pandas-ta
 Backtesting
 yfinance
@@ -13,3 +14,4 @@ pyarrow
 pytest
 mypy
 pandas-stubs
+setuptools<81 # Pinned for pandas-ta compatibility

--- a/src/prompts/quant_analyst.txt
+++ b/src/prompts/quant_analyst.txt
@@ -1,17 +1,26 @@
-You are a quantitative analyst. Your goal is to improve a trading strategy by analyzing its past performance.
+You are a world-class quantitative analyst specializing in algorithmic trading strategies. Your task is to improve a trading strategy based on its performance history. You will be given a history of backtest reports, and you must propose a new strategy configuration in JSON format.
 
-Below is the history of previous trading strategy backtests. Each entry includes the strategy configuration and its performance metrics.
+**Rules:**
+1.  You MUST ONLY respond with a single, valid JSON object. Do not include any other text, explanations, or markdown formatting.
+2.  The JSON object must conform to the following schema:
+    ```json
+    {{
+      "strategy_name": "A descriptive name, e.g., EMA_crossover_with_RSI_filter",
+      "indicators": [
+        {{ "name": "ema_fast", "function": "ema", "params": {{ "length": 20 }} }},
+        {{ "name": "ema_slow", "function": "ema", "params": {{ "length": 50 }} }}
+      ],
+      "buy_condition": "ema_fast > ema_slow",
+      "sell_condition": "ema_fast < ema_slow"
+    }}
+    ```
+3.  The `function` key for indicators must be a valid `pandas-ta` indicator function name (e.g., `ema`, `rsi`, `macd`, `bbands`).
+4.  The `buy_condition` and `sell_condition` strings can only reference indicator names defined in the `indicators` list and the standard OHLCV columns (`open`, `high`, `low`, `close`, `volume`).
+
+**Performance History:**
+This is the history of the previous iterations. Analyze what worked and what didn't. A high Sharpe Ratio is the primary goal.
 
 {history}
 
-Analyze the history. Identify what worked and what didn't. Propose a new strategy configuration in JSON format that is likely to perform better.
-
-Return only the JSON object. Do not include any other text or explanations. The JSON should conform to the following schema:
-{
-  "strategy_name": "string",
-  "indicators": [
-    { "name": "string", "function": "string", "params": { "key": "value" } }
-  ],
-  "buy_condition": "string",
-  "sell_condition": "string"
-}
+**Your Task:**
+Based on the history, provide the JSON for the next strategy to test. Aim to create a new strategy that is likely to outperform the best Sharpe Ratio seen so far. Do not simply repeat a previous strategy. Provide only the JSON.

--- a/src/services/llm_service.py
+++ b/src/services/llm_service.py
@@ -1,0 +1,119 @@
+"""
+This service handles all interactions with the configured LLM.
+"""
+import os
+import json
+import logging
+from typing import List, cast
+
+from openai import OpenAI, APIError
+from dotenv import load_dotenv
+
+from core.models import PerformanceReport, StrategyDefinition
+
+__all__ = ["LLMService"]
+
+# It's better to have a logger configured at the application level,
+# but for a service, we can create a default logger.
+logger = logging.getLogger(__name__)
+
+
+class LLMService:
+    """
+    Manages all communication with the LLM API.
+    """
+
+    def __init__(self) -> None:
+        load_dotenv()
+        self.provider = os.getenv("LLM_PROVIDER", "openai")
+        api_key = None
+        base_url = None
+
+        if self.provider == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY")
+            self.model = os.getenv("OPENROUTER_MODEL", "moonshotai/kimi-k2:free")
+            base_url = os.getenv("OPENROUTER_BASE_URL")
+        else: # Default to openai
+            api_key = os.getenv("OPENAI_API_KEY")
+            self.model = os.getenv("OPENAI_MODEL", "gpt-4-turbo")
+
+        if not api_key:
+            raise ValueError(f"API key for {self.provider} not found in .env file.")
+
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+
+        try:
+            with open("src/prompts/quant_analyst.txt", "r") as f:
+                self.prompt_template = f.read()
+        except FileNotFoundError:
+            logger.error("Prompt template file not found.")
+            raise
+
+    def _format_history(self, history: List[PerformanceReport]) -> str:
+        """Formats the history of reports into a string for the prompt."""
+        if not history:
+            return "No history available. This is the first iteration."
+
+        formatted_reports = []
+        for i, report in enumerate(history):
+            report_str = (
+                f"Iteration {i}:\n"
+                f"  Strategy: {report.strategy.model_dump_json()}\n"
+                f"  Sharpe Ratio: {report.sharpe_ratio:.2f}\n"
+                f"  Annual Return: {report.annual_return_pct:.2f}%\n"
+                f"  Max Drawdown: {report.max_drawdown_pct:.2f}%\n"
+                f"  Total Trades: {report.trade_summary.total_trades}\n"
+            )
+            formatted_reports.append(report_str)
+
+        return "\n---\n".join(formatted_reports)
+
+    # impure
+    def get_suggestion(self, history: List[PerformanceReport]) -> StrategyDefinition:
+        """
+        Sends the history to the LLM and gets a new strategy suggestion.
+        """
+        history_str = self._format_history(history)
+        prompt = self.prompt_template.format(history=history_str)
+
+        try:
+            logger.info(f"Sending request to LLM ({self.model})...")
+            completion = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are a quantitative analyst."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=0.7,
+            )
+
+            usage = completion.usage
+            if usage:
+                logger.info(
+                    f"LLM call successful. Tokens: "
+                    f"Prompt={usage.prompt_tokens}, "
+                    f"Completion={usage.completion_tokens}, "
+                    f"Total={usage.total_tokens}"
+                )
+
+            response_text = completion.choices[0].message.content
+            if not response_text:
+                raise ValueError("LLM returned an empty response.")
+
+            # The prompt asks for JSON only, so we parse it directly.
+            json_response = json.loads(response_text)
+
+            # Use Pydantic for validation
+            strategy_def = StrategyDefinition(**json_response)
+            return strategy_def
+
+        except APIError as e:
+            logger.error(f"LLM API error: {e}")
+            raise
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.error(f"Failed to parse LLM response as JSON: {e}")
+            logger.error(f"Raw response: {response_text}")
+            raise
+        except Exception as e:
+            logger.error(f"An unexpected error occurred in LLMService: {e}")
+            raise

--- a/src/services/report_generator.py
+++ b/src/services/report_generator.py
@@ -61,7 +61,7 @@ class ReportGenerator:
             avg_win_pct=winning_trades["ReturnPct"].mean() * 100,
             avg_loss_pct=losing_trades["ReturnPct"].mean() * 100,
             max_consecutive_losses=max_consecutive_losses,
-            avg_trade_duration_bars=int(trades["Duration"].mean().days),
+            avg_trade_duration_bars=int(trades["Duration"].dt.days.mean()),
         )
 
     @staticmethod

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,158 @@
+"""
+Tests for the LLMService.
+"""
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, Mock
+
+from openai import APIError
+from pydantic import ValidationError
+
+from services.llm_service import LLMService
+from core.models import (
+    PerformanceReport,
+    StrategyDefinition,
+    TradeSummary,
+    Indicator,
+)
+
+
+@pytest.fixture
+def mock_openai_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Mocks the OpenAI client."""
+    mock_client = MagicMock()
+    monkeypatch.setattr("services.llm_service.OpenAI", mock_client)
+    return mock_client
+
+
+@pytest.fixture
+def llm_service(mock_openai_client: MagicMock) -> LLMService:
+    """Provides an LLMService instance with a mocked client."""
+    # Set dummy env vars for the service to initialize
+    os.environ["LLM_PROVIDER"] = "openrouter"
+    os.environ["OPENROUTER_API_KEY"] = "dummy_key"
+    return LLMService()
+
+
+@pytest.fixture
+def sample_history() -> list[PerformanceReport]:
+    """Provides a sample history of performance reports."""
+    return [
+        PerformanceReport(
+            strategy=StrategyDefinition(
+                strategy_name="SMA_10_20",
+                indicators=[
+                    Indicator(
+                        name="sma10", function="sma", params={"length": 10}
+                    )
+                ],
+                buy_condition="sma10 > close",
+                sell_condition="sma10 < close",
+            ),
+            sharpe_ratio=1.2,
+            sortino_ratio=1.8,
+            annual_return_pct=15.5,
+            max_drawdown_pct=-10.0,
+            trade_summary=TradeSummary(total_trades=10, win_rate_pct=60.0, profit_factor=2.1, avg_win_pct=2.0, avg_loss_pct=-1.5, max_consecutive_losses=2, avg_trade_duration_bars=5),
+        )
+    ]
+
+
+def test_get_suggestion_success(
+    llm_service: LLMService,
+    mock_openai_client: MagicMock,
+    sample_history: list[PerformanceReport],
+) -> None:
+    """
+    Tests successful suggestion retrieval and parsing.
+    """
+    # Arrange
+    mock_response_content = {
+        "strategy_name": "New_Strategy",
+        "indicators": [{"name": "ema50", "function": "ema", "params": {"length": 50}}],
+        "buy_condition": "ema50 > close",
+        "sell_condition": "ema50 < close",
+    }
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = json.dumps(mock_response_content)
+    mock_completion.usage.prompt_tokens = 100
+    mock_completion.usage.completion_tokens = 50
+    mock_completion.usage.total_tokens = 150
+
+    # Configure the mock client instance returned by the constructor mock
+    mock_instance = mock_openai_client.return_value
+    mock_instance.chat.completions.create.return_value = mock_completion
+
+    # Act
+    result = llm_service.get_suggestion(sample_history)
+
+    # Assert
+    assert isinstance(result, StrategyDefinition)
+    assert result.strategy_name == "New_Strategy"
+    assert result.indicators[0].name == "ema50"
+    mock_instance.chat.completions.create.assert_called_once()
+    call_args = mock_instance.chat.completions.create.call_args
+    prompt_sent = call_args.kwargs["messages"][1]["content"]
+    assert "Iteration 0" in prompt_sent
+    assert "Sharpe Ratio: 1.20" in prompt_sent
+
+
+def test_get_suggestion_json_decode_error(
+    llm_service: LLMService,
+    mock_openai_client: MagicMock,
+    sample_history: list[PerformanceReport],
+) -> None:
+    """
+    Tests handling of a malformed JSON response from the LLM.
+    """
+    # Arrange
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = "This is not valid JSON."
+    mock_instance = mock_openai_client.return_value
+    mock_instance.chat.completions.create.return_value = mock_completion
+
+    # Act & Assert
+    with pytest.raises(json.JSONDecodeError):
+        llm_service.get_suggestion(sample_history)
+
+
+def test_get_suggestion_pydantic_validation_error(
+    llm_service: LLMService,
+    mock_openai_client: MagicMock,
+    sample_history: list[PerformanceReport],
+) -> None:
+    """
+    Tests handling of JSON that doesn't match the Pydantic model.
+    """
+    # Arrange
+    mock_response_content = {
+        "strategy_name": "Invalid_Strategy",
+        "indicators": [{"name": "ema50"}], # Missing 'function' and 'params'
+        "buy_condition": "ema50 > close",
+    } # Missing 'sell_condition'
+    mock_completion = MagicMock()
+    mock_completion.choices[0].message.content = json.dumps(mock_response_content)
+    mock_instance = mock_openai_client.return_value
+    mock_instance.chat.completions.create.return_value = mock_completion
+
+    # Act & Assert
+    with pytest.raises(ValidationError):
+        llm_service.get_suggestion(sample_history)
+
+
+def test_get_suggestion_api_error(
+    llm_service: LLMService,
+    mock_openai_client: MagicMock,
+    sample_history: list[PerformanceReport],
+) -> None:
+    """
+    Tests handling of an APIError from the OpenAI client.
+    """
+    # Arrange
+    mock_instance = mock_openai_client.return_value
+    mock_instance.chat.completions.create.side_effect = APIError("API Error", request=Mock(), body=None)
+
+    # Act & Assert
+    with pytest.raises(APIError):
+        llm_service.get_suggestion(sample_history)


### PR DESCRIPTION
This commit introduces the `LLMService`, responsible for interacting with an LLM provider to generate new trading strategy suggestions.

Key features:
- Supports both OpenAI and OpenRouter providers, configurable via `.env`.
- Loads a detailed prompt from `prompts/quant_analyst.txt`.
- Formats and sends the strategy performance history to the LLM.
- Parses and validates the JSON response into a `StrategyDefinition` model.
- Includes comprehensive unit tests with mocking for the service.

This commit also includes several stability and quality improvements discovered during development:
- Pins `numpy` and `setuptools` versions in `requirements.txt` to resolve dependency conflicts and warnings.
- Fixes a `mypy` type error in `report_generator.py`.
- Updates `pyproject.toml` to enforce `mypy --strict` on the `tests` directory.
- Updates `docs/tasks.md` to accurately reflect the status of completed foundational tasks.