### PR TITLE
feat: Implement StateManager for resumability

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -12,6 +12,7 @@ __all__ = [
     "StrategyDefinition",
     "TradeSummary",
     "PerformanceReport",
+    "RunState",
 ]
 
 
@@ -103,3 +104,12 @@ class PerformanceReport(BaseModel):
     max_drawdown_pct: float
     annual_return_pct: float
     trade_summary: TradeSummary
+
+
+class RunState(BaseModel):
+    """
+    Represents the state of a single optimization run for a ticker,
+    allowing the process to be resumed.
+    """
+    iteration_number: int
+    history: List[PerformanceReport]

--- a/src/services/state_manager.py
+++ b/src/services/state_manager.py
@@ -1,0 +1,78 @@
+"""
+Service for managing the state of an optimization run.
+"""
+import json
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from core.models import RunState
+
+__all__ = ["StateManager"]
+
+
+class StateManager:
+    """
+    Handles saving and loading of the application's run state,
+    enabling resumability.
+    """
+
+    def __init__(self, state_filepath: Path):
+        """
+        Initializes the StateManager.
+
+        Args:
+            state_filepath: The path to the JSON file where the state is stored.
+        """
+        self._state_filepath = state_filepath
+
+    # impure
+    def save_state(self, run_state: RunState) -> None:
+        """
+        Saves the given RunState to the state file atomically.
+
+        Args:
+            run_state: The RunState object to save.
+        """
+        # Use a temporary file and atomic rename to prevent corruption
+        temp_dir = self._state_filepath.parent
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode='w', delete=False, dir=temp_dir, suffix='.tmp'
+            ) as f:
+                temp_path = Path(f.name)
+                f.write(run_state.model_dump_json(indent=4))
+
+            temp_path.rename(self._state_filepath)
+        except Exception as e:
+            # If something goes wrong, try to clean up the temp file
+            if temp_path and temp_path.exists():
+                temp_path.unlink()
+            raise e
+
+    # impure
+    def load_state(self) -> RunState:
+        """
+        Loads the RunState from the state file.
+
+        If the file does not exist, it returns a new RunState object,
+        representing the start of a new run.
+
+        If the file is corrupted, it raises a ValueError.
+
+        Returns:
+            The loaded or a new RunState object.
+        """
+        if not self._state_filepath.exists():
+            return RunState(iteration_number=0, history=[])
+
+        try:
+            with open(self._state_filepath, 'r') as f:
+                data = json.load(f)
+            return RunState.model_validate(data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error decoding state file: {self._state_filepath}") from e
+        except Exception as e:
+            # Catches Pydantic validation errors and other issues
+            raise ValueError(f"Error loading state file: {self._state_filepath}") from e

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,120 @@
+"""
+Tests for the StateManager service.
+"""
+import json
+from pathlib import Path
+import pytest
+from core.models import RunState, PerformanceReport, StrategyDefinition, TradeSummary
+from services.state_manager import StateManager
+
+
+@pytest.fixture
+def test_dir(tmp_path: Path) -> Path:
+    """
+    Create a temporary directory for test files.
+    """
+    return tmp_path
+
+
+@pytest.fixture
+def state_filepath(test_dir: Path) -> Path:
+    """
+    Get the path to a test state file.
+    """
+    return test_dir / "test_run_state.json"
+
+
+@pytest.fixture
+def sample_run_state() -> RunState:
+    """
+    Create a sample RunState object for testing.
+    """
+    strategy_def = StrategyDefinition(
+        strategy_name="Test Strategy",
+        indicators=[],
+        buy_condition="Close > Open",
+        sell_condition="Close < Open",
+    )
+    trade_summary = TradeSummary(
+        total_trades=10,
+        win_rate_pct=50.0,
+        profit_factor=1.5,
+        avg_win_pct=2.0,
+        avg_loss_pct=-1.0,
+        max_consecutive_losses=3,
+        avg_trade_duration_bars=5,
+    )
+    report = PerformanceReport(
+        strategy=strategy_def,
+        sharpe_ratio=1.2,
+        sortino_ratio=1.8,
+        max_drawdown_pct=-15.0,
+        annual_return_pct=25.0,
+        trade_summary=trade_summary,
+    )
+    return RunState(iteration_number=1, history=[report])
+
+
+def test_save_and_load_state(
+    state_filepath: Path, sample_run_state: RunState
+) -> None:
+    """
+    Test that the StateManager can save a RunState and load it back correctly.
+    """
+    # Arrange
+    manager = StateManager(state_filepath)
+
+    # Act
+    manager.save_state(sample_run_state)
+    loaded_state = manager.load_state()
+
+    # Assert
+    assert state_filepath.exists()
+    assert loaded_state == sample_run_state
+    assert loaded_state.iteration_number == 1
+    assert len(loaded_state.history) == 1
+    assert loaded_state.history[0].sharpe_ratio == 1.2
+
+
+def test_load_state_non_existent_file(state_filepath: Path) -> None:
+    """
+    Test that loading a non-existent state file returns a default RunState.
+    """
+    # Arrange
+    manager = StateManager(state_filepath)
+
+    # Act
+    loaded_state = manager.load_state()
+
+    # Assert
+    assert not state_filepath.exists()
+    assert isinstance(loaded_state, RunState)
+    assert loaded_state.iteration_number == 0
+    assert len(loaded_state.history) == 0
+
+
+def test_load_state_corrupted_file(state_filepath: Path) -> None:
+    """
+    Test that loading a corrupted JSON file raises a ValueError.
+    """
+    # Arrange
+    state_filepath.write_text("this is not valid json")
+    manager = StateManager(state_filepath)
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Error decoding state file"):
+        manager.load_state()
+
+
+def test_load_state_invalid_schema(state_filepath: Path) -> None:
+    """
+    Test that loading a file with a different schema raises a ValueError.
+    """
+    # Arrange
+    invalid_data = {"wrong_key": "some_value"}
+    state_filepath.write_text(json.dumps(invalid_data))
+    manager = StateManager(state_filepath)
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Error loading state file"):
+        manager.load_state()


### PR DESCRIPTION
This commit introduces the `StateManager` service, which is responsible for saving and loading the application's run state. This is a critical component for making the optimization process robust and resumable, as required by rule [H-20].

Key changes:
- Created the `RunState` Pydantic model in `core/models.py` to represent the state of a run, including the iteration number and the history of performance reports.
- Implemented the `StateManager` class in `services/state_manager.py` with two main methods:
    - `save_state`: Atomically writes the `RunState` to a JSON file.
    - `load_state`: Reads the `RunState` from a JSON file, gracefully handling cases where the file doesn't exist or is corrupt.
- Added a comprehensive suite of unit tests for the `StateManager` in `tests/test_state_manager.py`, ensuring its reliability.
- Updated `docs/tasks.md` to mark the `StateManager` implementation as complete and clarified the integration step in the subsequent task.
- Added a new learning to `docs/memory.md` regarding Pydantic model validation behavior, which was discovered during testing.