### PR TITLE
Refactor `generate-report` for efficiency and correctness

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -312,4 +312,15 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   The reporting services and the final user-facing CLI are complete and functional.
 *   **Time estimate:** 4 hours
-*   **Status:** Not Started
+*   **Status:** In Progress - *Initial implementation of `generate-report` is functionally incorrect and inefficient. Requires refactoring.*
+
+---
+
+### Task 11 - Refactor `generate-report` Functionality
+*   **Rationale:** The current `generate-report` command is an inefficient placeholder. It must be refactored to use a dedicated, efficient "live" mode in the orchestrator to align with the project's quality standards.
+*   **Items:**
+    *   Implement `Orchestrator.generate_opportunities()` to check for signals on the latest data point only.
+    *   Implement `ReportGenerator.generate_opportunities_report()` to create the formatted Markdown table.
+    *   Refactor the `generate_report` CLI function to use the new orchestrator and generator methods.
+    *   Ensure the final report is saved to the `results/` directory.
+*   **Status:** Complete

--- a/praxis_engine/__init__.py
+++ b/praxis_engine/__init__.py
@@ -1,0 +1,99 @@
+"""
+Core command functions for the Praxis Engine CLI.
+"""
+import datetime
+from pathlib import Path
+import pandas as pd
+import typer
+
+from praxis_engine.core.logger import get_logger
+from praxis_engine.services.config_service import load_config
+
+log = get_logger(__name__)
+
+
+def verify_config(config_path: str) -> None:
+    """
+    Loads and verifies the configuration file.
+    """
+    log.info("Attempting to load configuration...")
+    try:
+        config = load_config(config_path)
+        log.info("Configuration loaded and validated successfully!")
+        log.info(config)
+    except Exception as e:
+        log.error(f"Error loading configuration: {e}")
+        raise typer.Exit(code=1)
+
+
+def backtest(config_path: str) -> None:
+    """
+    Runs a backtest for stocks defined in the config file.
+    """
+    from praxis_engine.core.orchestrator import Orchestrator
+    from praxis_engine.services.report_generator import ReportGenerator
+
+    log.info("Loading configuration...")
+    config = load_config(config_path)
+
+    orchestrator = Orchestrator(config)
+
+    all_trades = []
+    for stock in config.data.stocks_to_backtest:
+        trades = orchestrator.run_backtest(
+            stock, config.data.start_date, config.data.end_date
+        )
+        all_trades.extend(trades)
+
+    if all_trades:
+        log.info(f"Backtest complete. Total trades executed: {len(all_trades)}")
+        report_generator = ReportGenerator()
+        report = report_generator.generate_backtest_report(
+            all_trades, config.data.start_date, config.data.end_date
+        )
+
+        # Save the report
+        results_dir = Path("results")
+        results_dir.mkdir(exist_ok=True)
+        report_path = results_dir / "backtest_summary.md"
+
+        with open(report_path, "w") as f:
+            f.write(report)
+
+        log.info(f"Backtest report saved to {report_path}")
+        log.info("\n" + report)
+    else:
+        log.info("Backtest complete. No trades were executed.")
+
+
+def generate_report(config_path: str) -> None:
+    """
+    Runs the engine on the latest data to find new opportunities and saves a report.
+    """
+    from praxis_engine.core.orchestrator import Orchestrator
+    from praxis_engine.services.report_generator import ReportGenerator
+
+    log.info("Loading configuration...")
+    config = load_config(config_path)
+
+    orchestrator = Orchestrator(config)
+    report_generator = ReportGenerator()
+
+    opportunities = []
+    for stock in config.data.stocks_to_backtest:
+        # Use a lookback that's long enough for indicators but not excessive.
+        opportunity = orchestrator.generate_opportunities(stock, lookback_days=365)
+        if opportunity:
+            opportunities.append(opportunity)
+
+    report = report_generator.generate_opportunities_report(opportunities)
+
+    results_dir = Path("results")
+    results_dir.mkdir(exist_ok=True)
+    report_path = results_dir / f"opportunities_{datetime.date.today()}.md"
+
+    with open(report_path, "w") as f:
+        f.write(report)
+
+    log.info(f"Opportunities report saved to {report_path}")
+    log.info("\n" + report)

--- a/praxis_engine/core/models.py
+++ b/praxis_engine/core/models.py
@@ -75,6 +75,19 @@ class Trade(BaseModel):
     exit_price: float
     net_return_pct: float
     confidence_score: float
+    signal: Signal # Keep track of the signal that generated the trade
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class Opportunity(BaseModel):
+    """
+    Represents a potential trade opportunity that has been validated.
+    """
+    stock: str
+    signal_date: pd.Timestamp
+    signal: Signal
+    confidence_score: float
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/praxis_engine/main.py
+++ b/praxis_engine/main.py
@@ -1,107 +1,47 @@
 """
-Core command functions for the Praxis Engine CLI.
+CLI command definitions for the Praxis Engine.
 """
-import datetime
-from pathlib import Path
-import pandas as pd
 import typer
+import praxis_engine as main_logic
 
-from praxis_engine.core.logger import get_logger
-from praxis_engine.services.config_service import load_config
+app = typer.Typer(
+    name="praxis-engine",
+    help="A quantitative trading system for the Indian stock market.",
+    pretty_exceptions_show_locals=False,
+)
 
-log = get_logger(__name__)
-
-
-def verify_config(config_path: str) -> None:
+@app.command()
+def verify_config(
+    config_path: str = typer.Option(
+        "config.ini", "--config", "-c", help="Path to config."
+    )
+) -> None:
     """
     Loads and verifies the configuration file.
     """
-    log.info("Attempting to load configuration...")
-    try:
-        config = load_config(config_path)
-        log.info("Configuration loaded and validated successfully!")
-        log.info(config)
-    except Exception as e:
-        log.error(f"Error loading configuration: {e}")
-        raise typer.Exit(code=1)
+    main_logic.verify_config(config_path)
 
-
-def backtest(config_path: str) -> None:
+@app.command()
+def backtest(
+    config_path: str = typer.Option(
+        "config.ini", "--config", "-c", help="Path to config."
+    )
+) -> None:
     """
     Runs a backtest for stocks defined in the config file.
     """
-    from praxis_engine.core.orchestrator import Orchestrator
-    from praxis_engine.services.report_generator import ReportGenerator
+    main_logic.backtest(config_path)
 
-    log.info("Loading configuration...")
-    config = load_config(config_path)
-
-    orchestrator = Orchestrator(config)
-
-    all_trades = []
-    for stock in config.data.stocks_to_backtest:
-        trades = orchestrator.run_backtest(
-            stock, config.data.start_date, config.data.end_date
-        )
-        all_trades.extend(trades)
-
-    if all_trades:
-        log.info(f"Backtest complete. Total trades executed: {len(all_trades)}")
-        report_generator = ReportGenerator()
-        report = report_generator.generate_backtest_report(
-            all_trades, config.data.start_date, config.data.end_date
-        )
-
-        # Save the report
-        results_dir = Path("results")
-        results_dir.mkdir(exist_ok=True)
-        report_path = results_dir / "backtest_summary.md"
-
-        with open(report_path, "w") as f:
-            f.write(report)
-
-        log.info(f"Backtest report saved to {report_path}")
-        log.info("\n" + report)
-    else:
-        log.info("Backtest complete. No trades were executed.")
-
-
-def generate_report(config_path: str) -> None:
+@app.command()
+def generate_report(
+    config_path: str = typer.Option(
+        "config.ini", "--config", "-c", help="Path to config."
+    )
+) -> None:
     """
     Runs the engine on the latest data to find new opportunities.
     """
-    from praxis_engine.core.orchestrator import Orchestrator
+    main_logic.generate_report(config_path)
 
-    log.info("Loading configuration...")
-    config = load_config(config_path)
-
-    orchestrator = Orchestrator(config)
-
-    # For weekly report, we are interested in the latest signals.
-    # We run the "backtest" but only care about signals from the last few days.
-    end_date = datetime.date.today().strftime("%Y-%m-%d")
-    start_date = (datetime.date.today() - datetime.timedelta(days=365 * 5)).strftime(
-        "%Y-%m-%d"
-    )  # 5 years of data for context
-
-    all_opportunities = []
-
-    for stock in config.data.stocks_to_backtest:
-        # This is a simplified approach. A more robust implementation would have a dedicated
-        # "live" run mode in the orchestrator.
-        trades = orchestrator.run_backtest(stock, start_date, end_date)
-        if trades:
-            # For this report, we only care about the most recent trade signal
-            last_trade = trades[-1]
-            # Check if the signal is recent (e.g., within the last 7 days)
-            if (pd.Timestamp.today() - last_trade.entry_date).days <= 7:
-                all_opportunities.append(last_trade)
-
-    if all_opportunities:
-        log.info("=== Weekly Opportunities Report ===")
-        for opp in all_opportunities:
-            log.info(
-                f"Stock: {opp.stock}, Entry: {opp.entry_price:.2f}, Confidence: {opp.confidence_score:.2f}"
-            )
-    else:
-        log.info("No new opportunities found in the last 7 days.")
+if __name__ == "__main__":
+    app()

--- a/praxis_engine/services/execution_simulator.py
+++ b/praxis_engine/services/execution_simulator.py
@@ -105,4 +105,5 @@ class ExecutionSimulator:
             exit_price=exit_price,
             net_return_pct=net_return_pct,
             confidence_score=confidence_score,
+            signal=signal,
         )

--- a/praxis_engine/services/report_generator.py
+++ b/praxis_engine/services/report_generator.py
@@ -5,7 +5,7 @@ from typing import List
 import pandas as pd
 import numpy as np
 
-from praxis_engine.core.models import Trade
+from praxis_engine.core.models import Trade, Opportunity
 
 class ReportGenerator:
     """
@@ -89,3 +89,26 @@ class ReportGenerator:
             "max_drawdown": max_drawdown,
             "win_rate": win_rate,
         }
+
+    def generate_opportunities_report(
+        self, opportunities: List[Opportunity]
+    ) -> str:
+        """
+        Generates a markdown report for new trading opportunities.
+        """
+        if not opportunities:
+            return "## Weekly Opportunities Report\n\nNo new high-confidence opportunities found."
+
+        header = "| Stock | Signal Date | Entry Price | Stop-Loss | Confidence Score |\n"
+        separator = "|---|---|---|---|---|\n"
+        rows = [
+            f"| {opp.stock} | {opp.signal_date.date()} | {opp.signal.entry_price:.2f} | {opp.signal.stop_loss:.2f} | {opp.confidence_score:.2f} |"
+            for opp in opportunities
+        ]
+
+        return (
+            "## Weekly Opportunities Report\n\n"
+            + header
+            + separator
+            + "\n".join(rows)
+        )

--- a/results/opportunities_2025-08-26.md
+++ b/results/opportunities_2025-08-26.md
@@ -1,0 +1,3 @@
+## Weekly Opportunities Report
+
+No new high-confidence opportunities found.

--- a/run.py
+++ b/run.py
@@ -1,53 +1,25 @@
-#!/usr/bin/env python
 """
-Main CLI entry point for the Praxis Engine.
+Main entry point for the Praxis Engine application.
+
+This script is responsible for:
+1. Loading environment variables from the .env file.
+2. Setting up the Typer CLI application.
 """
+from pathlib import Path
 import typer
 from dotenv import load_dotenv
 
-from praxis_engine import main
+# --- Application Startup ---
+# Load environment variables FIRST, before any application code is imported.
+# Explicitly provide the path to the .env file to avoid ambiguity.
+dotenv_path = Path('.env')
+load_dotenv(dotenv_path=dotenv_path)
 
-# Load environment variables from .env file
-load_dotenv()
+# Import the application's CLI module AFTER loading the environment.
+from praxis_engine import main as cli_main
 
-app = typer.Typer(
-    name="praxis-engine",
-    help="A quantitative trading system for the Indian stock market.",
-    pretty_exceptions_show_locals=False,
-)
-
-@app.command()
-def verify_config(
-    config_path: str = typer.Option(
-        "config.ini", "--config", "-c", help="Path to config."
-    )
-) -> None:
-    """
-    Loads and verifies the configuration file.
-    """
-    main.verify_config(config_path)
-
-@app.command()
-def backtest(
-    config_path: str = typer.Option(
-        "config.ini", "--config", "-c", help="Path to config."
-    )
-) -> None:
-    """
-    Runs a backtest for stocks defined in the config file.
-    """
-    main.backtest(config_path)
-
-@app.command()
-def generate_report(
-    config_path: str = typer.Option(
-        "config.ini", "--config", "-c", help="Path to config."
-    )
-) -> None:
-    """
-    Runs the engine on the latest data to find new opportunities.
-    """
-    main.generate_report(config_path)
+# The `app` object in `cli_main` is the Typer application.
+app = cli_main.app
 
 if __name__ == "__main__":
     app()

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from typing import List
 
-from praxis_engine.core.models import Trade
+from praxis_engine.core.models import Trade, Signal
 from praxis_engine.services.report_generator import ReportGenerator
 
 @pytest.fixture
@@ -10,6 +10,14 @@ def sample_trades() -> List[Trade]:
     """
     Provides a sample list of Trade objects for testing.
     """
+    # Create a dummy signal to be used in trades
+    dummy_signal = Signal(
+        entry_price=100.0,
+        stop_loss=95.0,
+        exit_target_days=20,
+        frames_aligned=["daily"],
+        sector_vol=0.15,
+    )
     trades = [
         Trade(
             stock="RELIANCE.NS",
@@ -19,6 +27,7 @@ def sample_trades() -> List[Trade]:
             exit_price=110.0,
             net_return_pct=0.10,
             confidence_score=0.8,
+            signal=dummy_signal,
         ),
         Trade(
             stock="RELIANCE.NS",
@@ -28,6 +37,7 @@ def sample_trades() -> List[Trade]:
             exit_price=105.0,
             net_return_pct=-0.045,
             confidence_score=0.75,
+            signal=dummy_signal,
         ),
         Trade(
             stock="TCS.NS",
@@ -37,6 +47,7 @@ def sample_trades() -> List[Trade]:
             exit_price=220.0,
             net_return_pct=0.10,
             confidence_score=0.9,
+            signal=dummy_signal,
         ),
     ]
     return trades


### PR DESCRIPTION
The previous `generate-report` command was a placeholder that inefficiently re-ran a full backtest for each stock. This was computationally expensive and did not produce the correct report artifact.

This commit refactors the functionality by:
- Adding a new `generate_opportunities` method to the `Orchestrator` that efficiently checks for signals on only the latest data.
- Adding a `generate_opportunities_report` method to the `ReportGenerator` to create a formatted markdown report.
- Rewriting the `generate-report` CLI command to use the new efficient pipeline.
- Introducing a new `Opportunity` data model to represent potential trades.
- Updating `tasks.md` and `architecture.md` to reflect the changes.
- Fixing a persistent issue with environment variable loading by refactoring the application entry point.