### PR TITLE
Refactor Orchestrator to Fix Lookahead Bias and Inefficiency

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -173,3 +173,22 @@ This document provides a detailed, sequential list of tasks required to build th
     *   All new code is implemented, unit-tested, and integrated into the orchestrator. The `config.ini` is updated with the new section and documentation.
 *   **Time estimate:** 6 hours
 *   **Status:** Done
+
+---
+
+## Epic 5: Critical Refactoring & Validation
+
+*Goal: To correct severe architectural flaws, data leakage, and inefficiencies discovered during a full-code review. These fixes are non-negotiable for the system to produce scientifically valid results.*
+
+---
+
+### Task 12 — Fix Lookahead Bias and Orchestrator Logic
+
+*   **Rationale:** A full code review uncovered critical flaws that invalidated backtest results. The `Orchestrator` contained lookahead bias in its ATR calculation and had a catastrophically inefficient `generate_opportunities` method. This task corrects these core architectural problems to restore experimental integrity.
+*   **Items to implement:**
+    1.  **Fix ATR Lookahead Bias:** Move the ATR calculation from a pre-computation step on the full dataset to *inside* the `run_backtest` walk-forward loop. The ATR must be calculated only on the point-in-time `window` dataframe at each step.
+    2.  **Refactor `generate_opportunities`:** The existing method, which ran a full backtest for every stock, was deleted. It has been replaced with a new, efficient implementation that:
+        a. Checks for a signal and validates it only on the most recent data point.
+        b. If the signal is valid, it calls a new helper method (`_calculate_historical_stats_for_llm`) to perform a lean, focused backtest on the data *prior* to the signal date.
+        c. This provides the necessary historical context to the LLM without re-running the main backtester.
+*   **Status:** Done

--- a/results/backtest_summary.md
+++ b/results/backtest_summary.md
@@ -7,9 +7,9 @@
 ### Key Performance Indicators
 | Metric | Value |
 | --- | --- |
-| Net Annualized Return | 14.61% |
-| Sharpe Ratio | 0.72 |
-| Profit Factor | 2.46 |
-| Maximum Drawdown | -17.64% |
+| Net Annualized Return | 14.80% |
+| Sharpe Ratio | 0.74 |
+| Profit Factor | 2.60 |
+| Maximum Drawdown | -16.57% |
 | Win Rate | 64.71% |
 


### PR DESCRIPTION
This commit addresses critical flaws in the backtesting and opportunity generation logic within the Orchestrator.

- Fixes a lookahead bias in the ATR calculation by moving it inside the point-in-time walk-forward loop.
- Replaces the catastrophically inefficient `generate_opportunities` method with a lean, two-step process. The new process first checks for a signal on the latest data and only then calculates historical statistics for the LLM audit, avoiding a full backtest run for every stock.
- Updates tests to be consistent with the refactored logic.
- Updates `tasks.md` and `memory.md` to document the architectural flaws and the fixes applied.