### PR TITLE
feat: Add reproducibility metadata to backtest reports

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -36,6 +36,16 @@ This document provides a detailed, sequential list of tasks required to build th
 
 ---
 
+### Task 1.2 — Solidify Project Dependencies
+*   **Rationale:** The project is missing a formal dependency management file (e.g., `requirements.txt`). Several libraries (`typer`, `pyarrow`, `openai`, etc.) were required to run the backtest but were not installed as part of the initial setup, causing runtime errors. This makes the project difficult to set up and violates the principle of a reproducible environment.
+*   **Items to implement:**
+    1.  Create a `requirements.txt` file that lists all necessary dependencies for running the application and the tests.
+    2.  Update the `README.md` or a new `CONTRIBUTING.md` with clear instructions on how to set up the development environment using `pip install -r requirements.txt`.
+    3.  Ensure all required packages are included so that a fresh checkout can be run with a single installation command.
+*   **Status:** To Do
+
+---
+
 ### Task 2 — Data Service for Indian Markets
 
 *   **Rationale:** Data is the lifeblood. This service must be robust, efficient, and acutely aware of Indian market specifics. We will use the correct data sources and implement caching to make research fast and reproducible.
@@ -306,7 +316,7 @@ Understood. Task 14 is complete. Here are the updated `tasks.md` entries for the
 *   **Tests to cover:**
     *   A unit test for the new Git hash utility function, mocking the `subprocess.run` call.
     *   Update `tests/test_report_generator.py` to check that the metadata section is correctly rendered in the output string.
-*   **Status:** To Do
+*   **Status:** Done
 
 ---
 

--- a/praxis_engine/core/models.py
+++ b/praxis_engine/core/models.py
@@ -112,6 +112,15 @@ class Opportunity(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
+class RunMetadata(BaseModel):
+    """
+    Holds metadata about a specific backtest run for reproducibility.
+    """
+    run_timestamp: str
+    config_path: str
+    git_commit_hash: str
+
+
 class SensitivityAnalysisConfig(BaseModel):
     """
     Configuration for the sensitivity analysis module.

--- a/praxis_engine/services/report_generator.py
+++ b/praxis_engine/services/report_generator.py
@@ -1,18 +1,27 @@
 """
 Service for generating reports from backtest results.
 """
-from typing import List
+from typing import List, Optional
 import pandas as pd
 import numpy as np
 
-from praxis_engine.core.models import BacktestSummary, Trade, Opportunity
+from praxis_engine.core.models import BacktestSummary, Trade, Opportunity, RunMetadata
+from praxis_engine.core.logger import get_logger
+
+log = get_logger(__name__)
 
 class ReportGenerator:
     """
     Generates reports from a list of trades.
     """
 
-    def generate_backtest_report(self, trades: List[Trade], start_date: str, end_date: str) -> str:
+    def generate_backtest_report(
+        self,
+        trades: List[Trade],
+        start_date: str,
+        end_date: str,
+        metadata: Optional[RunMetadata] = None,
+    ) -> str:
         """
         Generates a summary report from a list of trades.
         """
@@ -22,9 +31,20 @@ class ReportGenerator:
         # Placeholder for KPI calculations
         kpis = self._calculate_kpis(trades, start_date, end_date)
 
+        metadata_section = ""
+        if metadata:
+            metadata_section = f"""
+### Run Configuration & Metadata
+| Parameter | Value |
+| --- | --- |
+| Run Timestamp | {metadata.run_timestamp} |
+| Config File | `{metadata.config_path}` |
+| Git Commit Hash | `{metadata.git_commit_hash}` |
+"""
+
         report = f"""
 ## Backtest Report
-
+{metadata_section}
 **Period:** {start_date} to {end_date}
 **Total Trades:** {len(trades)}
 

--- a/praxis_engine/utils.py
+++ b/praxis_engine/utils.py
@@ -1,0 +1,32 @@
+import subprocess
+from praxis_engine.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# impure
+def get_git_commit_hash() -> str:
+    """
+    Retrieves the short git commit hash of the current HEAD.
+
+    Returns:
+        The short git commit hash as a string, or "N/A" if git is not
+        installed, it's not a git repository, or any other error occurs.
+    """
+    try:
+        # Execute the git command to get the short hash
+        process = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding='utf-8' # Explicitly set encoding
+        )
+        return process.stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        # Handle cases where git is not installed or it's not a git repo
+        logger.warning(f"Could not get git hash: {e}")
+        return "N/A"
+    except Exception as e:
+        # Catch any other unexpected errors
+        logger.error(f"An unexpected error occurred while getting git hash: {e}")
+        return "N/A"

--- a/results/backtest_summary.md
+++ b/results/backtest_summary.md
@@ -1,6 +1,13 @@
 
 ## Backtest Report
 
+### Run Configuration & Metadata
+| Parameter | Value |
+| --- | --- |
+| Run Timestamp | 2025-08-30 19:01:38 UTC |
+| Config File | `config.ini` |
+| Git Commit Hash | `dec6f51` |
+
 **Period:** 2018-01-01 to 2025-08-25
 **Total Trades:** 1
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from typing import List
 
-from praxis_engine.core.models import BacktestSummary, Trade, Signal
+from praxis_engine.core.models import BacktestSummary, Trade, Signal, RunMetadata
 from praxis_engine.services.report_generator import ReportGenerator
 
 @pytest.fixture
@@ -60,6 +60,26 @@ def test_generate_backtest_report_no_trades() -> None:
     report_generator = ReportGenerator()
     report = report_generator.generate_backtest_report([], "2023-01-01", "2023-12-31")
     assert "No trades were executed" in report
+
+
+def test_generate_backtest_report_with_metadata(sample_trades: List[Trade]) -> None:
+    """
+    Tests that the report generator correctly renders the metadata section.
+    """
+    report_generator = ReportGenerator()
+    metadata = RunMetadata(
+        run_timestamp="2025-08-30 12:00:00 UTC",
+        config_path="config.ini",
+        git_commit_hash="abcdef1",
+    )
+    report = report_generator.generate_backtest_report(
+        sample_trades, "2023-01-01", "2023-12-31", metadata=metadata
+    )
+
+    assert "Run Configuration & Metadata" in report
+    assert "| Run Timestamp | 2025-08-30 12:00:00 UTC |" in report
+    assert "| Config File | `config.ini` |" in report
+    assert "| Git Commit Hash | `abcdef1` |" in report
 
 
 def test_calculate_kpis_with_sample_data(sample_trades: List[Trade]) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from praxis_engine.utils import get_git_commit_hash
+
+def test_get_git_commit_hash_success():
+    """
+    Tests that get_git_commit_hash returns the correct hash on success.
+    """
+    # Mock the subprocess.run call to simulate a successful git command
+    mock_process = MagicMock()
+    mock_process.stdout = "abcdef1\n"
+    mock_process.check_returncode.return_value = None  # Not needed as check=True handles it
+
+    with patch('subprocess.run', return_value=mock_process) as mock_run:
+        commit_hash = get_git_commit_hash()
+
+        # Assert that the function returns the stripped hash
+        assert commit_hash == "abcdef1"
+
+        # Assert that subprocess.run was called with the correct arguments
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding='utf-8'
+        )
+
+def test_get_git_commit_hash_git_not_found():
+    """
+    Tests that get_git_commit_hash returns 'N/A' when git is not installed.
+    """
+    # Mock subprocess.run to raise FileNotFoundError
+    with patch('subprocess.run', side_effect=FileNotFoundError("git not found")) as mock_run:
+        commit_hash = get_git_commit_hash()
+
+        # Assert that the function returns "N/A"
+        assert commit_hash == "N/A"
+
+def test_get_git_commit_hash_not_a_git_repo():
+    """
+    Tests that get_git_commit_hash returns 'N/A' when not in a git repository.
+    """
+    # Mock subprocess.run to raise CalledProcessError
+    error = subprocess.CalledProcessError(
+        returncode=128,
+        cmd=["git", "rev-parse", "--short", "HEAD"],
+        stderr="fatal: not a git repository"
+    )
+    with patch('subprocess.run', side_effect=error) as mock_run:
+        commit_hash = get_git_commit_hash()
+
+        # Assert that the function returns "N/A"
+        assert commit_hash == "N/A"


### PR DESCRIPTION
This commit implements Task 17 from `docs/tasks.md`.

It introduces reproducibility metadata to the backtest summary report. Each report now includes a "Run Configuration & Metadata" section containing:
- The timestamp of the backtest run.
- The path to the configuration file used.
- The Git commit hash of the codebase at the time of the run.

To achieve this, the following changes were made:
- A new utility function `get_git_commit_hash` was created in a new `praxis_engine/utils.py` file.
- A `RunMetadata` Pydantic model was added for type-safe handling of the metadata.
- The main CLI in `praxis_engine/main.py` was updated to collect this metadata at the start of a backtest run.
- The `ReportGenerator` was updated to render this metadata in the final report.
- Unit tests were added for the new utility and the report generator updates.
- `docs/tasks.md` was updated to mark Task 17 as "Done" and a new task was added to address dependency management issues discovered during the process.