### PR TITLE
fix: Restore run.py entry point

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import sys
+from pathlib import Path
+
+# Add the project root to the python path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from praxis_engine.main import app
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
This commit restores the `run.py` script.

The script was previously removed based on a deprecation notice in the project documentation. This change restores it as per user feedback to maintain it as a valid entry point for the application.