### PR TITLE
feat: Add universe analyzer script for strategy specialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ python run.py backtest
 ```
 This will fetch the necessary data, run the walk-forward backtest for each stock, and print the results to the console.
 
+### Universe Curation
+
+The strategy implemented in this engine is a specialist, designed for mean-reverting stocks. Running it on a broad universe of stocks (like the full Nifty 500) can be inefficient. A helper script is provided to pre-filter the universe and identify the most suitable candidates.
+
+To generate a curated list of mean-reverting stocks:
+```bash
+python scripts/universe_analyzer.py
+```
+This script will analyze a list of stocks using an out-of-sample data period, calculate their Hurst exponents, and print a copy-paste-ready list of tickers with `Hurst < 0.5`. You can then use this list to update the `stocks_to_backtest` parameter in your `config.ini`.
+
 ## Project Structure
 
 -   `praxis_engine/`: The main source code for the engine.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -198,3 +198,9 @@ A full code review identified several critical, interacting flaws in the `Orches
 1.  **LLM API Connection Errors:** The backtest runs are consistently failing with `APIConnectionError` when trying to reach the OpenRouter service. This prevents any signal from passing the LLM audit, effectively halting the strategy. This has been documented as **Task 23** to be investigated further.
 
 2.  **`yfinance` Data Failures:** The `DataService` failed to fetch data for `HDFC.NS` and `ICICI.NS`, reporting a `YFTzMissingError`. The error message `possibly delisted; no timezone found` suggests these tickers may have changed or been delisted. This highlights the need for a more robust process for maintaining the stock list in `config.ini`.
+
+## Task 25 Learnings
+
+1.  **Strategy Specialization:** Backtesting results showed that the mean-reversion strategy is a specialist. It performs well on certain types of stocks (those exhibiting mean-reverting characteristics) and poorly on others (strong trending stocks). Running the backtester on a broad, uncurated universe is inefficient and leads to poor overall results.
+    *   **Fix:** A dedicated analysis script, `scripts/universe_analyzer.py`, was created. This script performs an out-of-sample analysis on a stock universe, calculates the Hurst exponent for each, and identifies the most promising mean-reverting candidates.
+    *   **Lesson:** Instead of trying to create a universal strategy that works on all assets, it is often more pragmatic and effective to create a specialized strategy and then build tools to curate the dataset to match the strategy's strengths. This simplifies the problem and focuses computational resources where they are most likely to yield results.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -463,4 +463,23 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   The script is created and functional. The `README.md` is updated with instructions for its use.
 *   **Time estimate:** 3 hours
+*   **Status:** Done
+
+---
+### Task 26 — Update Stock Universe with Curated List
+
+*   **Rationale:** (Nadh) The `universe_analyzer.py` script (Task 25) was created to provide a data-driven list of mean-reverting stocks. The final step to operationalize this finding is to update the system's configuration to use this curated list. This ensures that the backtester's resources are focused only on the stocks where the strategy has the highest probability of being applicable, directly applying the key learning from previous, broader backtests.
+*   **Items to implement:**
+    1.  Run the `scripts/universe_analyzer.py` script to generate the list of mean-reverting tickers.
+    2.  Copy the output list of tickers.
+    3.  Open `config.ini` and replace the value of the `stocks_to_backtest` parameter in the `[data]` section with the new, curated list.
+    4.  Run a full backtest using the `run.py backtest` command to confirm the system runs correctly with the new, specialized stock universe.
+*   **Tests to cover:**
+    *   The primary test is to run the backtester and ensure it completes without errors using the new stock list.
+*   **Acceptance Criteria (AC):**
+    *   The `config.ini` file is updated with a list of stocks identified as mean-reverting by the universe analyzer.
+    *   A backtest run completes successfully using this new configuration.
+*   **Definition of Done (DoD):**
+    *   The `config.ini` file is updated and a successful backtest has been run.
+*   **Time estimate:** 1 hour
 *   **Status:** To Do

--- a/scripts/universe_analyzer.py
+++ b/scripts/universe_analyzer.py
@@ -1,0 +1,114 @@
+# --- IMPORTS ---
+import logging
+import warnings
+from pathlib import Path
+import pandas as pd
+import sys
+
+# Ensure the package is in the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from praxis_engine.core.statistics import hurst_exponent
+from praxis_engine.services.data_service import DataService
+from praxis_engine.services.config_service import ConfigService
+from praxis_engine.core.logger import setup_file_logger
+
+# --- SETUP ---
+warnings.filterwarnings("ignore", category=FutureWarning)
+# Use the file logger setup from the core library
+setup_file_logger(file_name="universe_analyzer.log")
+log = logging.getLogger(__name__)
+
+# --- CONSTANTS ---
+# Using a smaller, representative list for this script as per task description.
+# A full Nifty 500 list would be read from a file in a production scenario.
+NIFTY_500_SUBSET = [
+    "RELIANCE.NS", "TCS.NS", "HDFCBANK.NS", "ICICIBANK.NS", "INFY.NS",
+    "BHARTIARTL.NS", "SBIN.NS", "LICI.NS", "HINDUNILVR.NS", "ITC.NS",
+    "LT.NS", "BAJFINANCE.NS", "HCLTECH.NS", "MARUTI.NS", "SUNPHARMA.NS",
+    "ADANIENT.NS", "KOTAKBANK.NS", "TITAN.NS", "ONGC.NS", "TATAMOTORS.NS",
+    "NTPC.NS", "AXISBANK.NS", "DMART.NS", "ADANIGREEN.NS", "ADANIPORTS.NS",
+    "ULTRACEMCO.NS", "ASIANPAINT.NS", "COALINDIA.NS", "BAJAJFINSV.NS",
+    "POWERGRID.NS", "WIPRO.NS", "NESTLEIND.NS", "M&M.NS", "IOC.NS",
+    "DLF.NS", "SBILIFE.NS", "GRASIM.NS", "HDFCLIFE.NS", "PIDILITIND.NS",
+    "BAJAJ-AUTO.NS", "INDUSINDBK.NS", "JSWSTEEL.NS", "CIPLA.NS", "VEDL.NS",
+    "ADANIPOWER.NS", "EICHERMOT.NS", "DRREDDY.NS", "TATASTEEL.NS", "HEROMOTOCO.NS"
+]
+
+OUT_OF_SAMPLE_START = "2010-01-01"
+OUT_OF_SAMPLE_END = "2017-12-31"
+HURST_THRESHOLD = 0.5
+
+# --- SCRIPT LOGIC ---
+
+# impure
+def analyze_universe(tickers: list[str], start_date: str, end_date: str) -> pd.DataFrame:
+    """
+    Analyzes a universe of stocks to find mean-reverting candidates.
+
+    Args:
+        tickers: A list of stock tickers to analyze.
+        start_date: The start date for the analysis period.
+        end_date: The end date for the analysis period.
+
+    Returns:
+        A pandas DataFrame with tickers and their Hurst exponents,
+        sorted by the Hurst exponent.
+    """
+    log.info(f"Starting universe analysis for {len(tickers)} stocks...")
+    log.info(f"Analysis period: {start_date} to {end_date}")
+
+    config_service = ConfigService(path="config.ini")
+    config = config_service.load_config()
+    data_service = DataService(cache_dir=config.data.cache_dir)
+
+    results = []
+
+    for ticker in tickers:
+        try:
+            log.debug(f"Fetching data for {ticker}...")
+            stock_data = data_service.get_data(ticker, start_date, end_date)
+
+            if stock_data is None or stock_data.empty:
+                log.warning(f"No data found for {ticker}. Skipping.")
+                continue
+
+            # Ensure there's enough data to calculate Hurst
+            if len(stock_data) < 100:
+                log.warning(f"Not enough data for {ticker} (len: {len(stock_data)}). Skipping.")
+                continue
+
+            h = hurst_exponent(stock_data["Close"])
+            log.debug(f"Hurst exponent for {ticker}: {h:.4f}")
+            results.append({"ticker": ticker, "hurst": h})
+
+        except Exception as e:
+            log.error(f"Failed to process {ticker}. Error: {e}", exc_info=False)
+
+    log.info("Analysis complete. Compiling results...")
+    return pd.DataFrame(results).sort_values(by="hurst", ascending=True)
+
+
+def main():
+    """Main function to run the universe analysis."""
+    # impure
+    results_df = analyze_universe(
+        tickers=NIFTY_500_SUBSET,
+        start_date=OUT_OF_SAMPLE_START,
+        end_date=OUT_OF_SAMPLE_END,
+    )
+
+    mean_reverting_stocks = results_df[results_df["hurst"] < HURST_THRESHOLD]
+
+    print("\n--- Universe Analysis Results ---")
+    print(f"Found {len(mean_reverting_stocks)} potential mean-reverting stocks (Hurst < {HURST_THRESHOLD}):")
+    print("-" * 35)
+
+    # Print a copy-paste ready list for config.ini
+    stock_list_str = ", ".join(mean_reverting_stocks["ticker"].tolist())
+    print("\n[COPY-PASTE FOR CONFIG.INI]")
+    print(f"stocks_to_backtest = {stock_list_str}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new script, `scripts/universe_analyzer.py`, to fulfill Task 25.

The script is designed to pre-filter a stock universe to find the most suitable mean-reverting candidates for the Praxis strategy. It works by calculating the Hurst exponent for each stock over an out-of-sample period and identifying those with H < 0.5.

This is a direct application of the learning that the core strategy is a specialist and performs best when run on a curated list of stocks.

This change also includes:
- Updates to `docs/tasks.md` to mark Task 25 as complete and add a follow-up task.
- Instructions in `README.md` on how to use the new script.
- A new entry in `docs/memory.md` to record the key learning from this task.