### PR TITLE
feat: Implement single-pass historical simulation for LLM stats

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -212,3 +212,17 @@ A full code review identified several critical, interacting flaws in the `Orches
     *   **Issue 2:** `np.polyfit()` is not supported. The initial attempt to replace it with `np.linalg.lstsq()` also failed, as `lstsq` is not supported either.
     *   **Fix:** A manual implementation of simple linear regression was used to calculate the slope, which is compatible with Numba and avoids unsupported functions.
     *   **Lesson:** While Numba is powerful, it has a subset of supported Python and NumPy features in its high-performance `nopython` mode. When a function fails to compile, the traceback must be inspected carefully to identify the unsupported feature. Often, high-level functions like `polyfit` need to be replaced with their lower-level mathematical equivalents.
+
+## Task 30 Learnings
+
+1.  **Mock `side_effect` Consumption:** When testing a method that internally calls another method that also uses mocked services with `side_effect` lists, it's crucial to be aware that the `side_effect` lists are consumed by the internal method calls. This can lead to unexpected behavior in the main method's test, as the mocks might not return the expected values.
+    *   **Fix:** In tests that are not directly testing the new method, patch the new method itself to prevent it from running and consuming the mocks. This isolates the test to the logic of the main method.
+    *   **Lesson:** When testing complex objects with nested method calls that use mocks, be mindful of the mock consumption order. Patching internal methods can help isolate the logic under test.
+
+2.  **Mocking vs. Real Objects in Tests:** Using `MagicMock` for complex objects like `pd.Timestamp` or custom data models can sometimes lead to subtle issues with equality comparisons.
+    *   **Fix:** In the test for `_pre_calculate_historical_performance`, `MagicMock` for `Trade` objects was replaced with real `Trade` objects. This made the test more robust and easier to debug.
+    *   **Lesson:** For complex data objects, it's often better to use real instances in tests instead of mocks. This avoids potential issues with mock behavior and makes the tests more realistic.
+
+3.  **Mock `side_effect` List Construction:** When using a list as a `side_effect` for a mock, the list is consumed sequentially on each call. The construction of this list must precisely match the expected call order in the test.
+    *   **Fix:** The `side_effect` list for `generate_signal` was re-calculated to have `None` values at the correct indices to match the calls made in the test loop, ensuring that `Signal` objects were returned at the intended times.
+    *   **Lesson:** Be meticulous when constructing `side_effect` lists for mocks. The order and content must exactly match the sequence of calls in the code being tested.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -601,4 +601,4 @@ This document provides a detailed, sequential list of tasks required to build th
 *   **Definition of Done (DoD):**
     *   The new pre-calculation method is implemented and fully unit-tested for correctness. The main backtest loop is refactored to use the pre-calculated results. The old, inefficient method is deleted.
 *   **Time estimate:** 10 hours
-*   **Status:** To Do
+*   **Status:** Done

--- a/results/backtest_summary.md
+++ b/results/backtest_summary.md
@@ -4,9 +4,9 @@
 ### Run Configuration & Metadata
 | Parameter | Value |
 | --- | --- |
-| Run Timestamp | 2025-09-04 01:39:21 UTC |
+| Run Timestamp | 2025-09-03 20:31:54 UTC |
 | Config File | `config.ini` |
-| Git Commit Hash | `e2672cf` |
+| Git Commit Hash | `dd6e909` |
 
 **Period:** 2018-01-01 to 2025-08-25
 **Total Trades:** 383
@@ -70,12 +70,12 @@
 | NESTLEIND.NS | 103.90% | 21 | 23 | 2 | 0 |
 | COALINDIA.NS | 27.08% | 29 | 38 | 9 | 0 |
 | SBIN.NS | 257.22% | 19 | 20 | 1 | 0 |
-| ONGC.NS | 46.64% | 33 | 36 | 3 | 0 |
 | WIPRO.NS | -46.15% | 37 | 43 | 6 | 0 |
+| ONGC.NS | 46.64% | 33 | 36 | 3 | 0 |
 | ADANIPORTS.NS | 12.93% | 27 | 32 | 5 | 0 |
 | RELIANCE.NS | 177.36% | 28 | 28 | 0 | 0 |
-| NTPC.NS | 2.70% | 31 | 34 | 3 | 0 |
 | ICICIBANK.NS | 140.84% | 20 | 23 | 3 | 0 |
+| NTPC.NS | 2.70% | 31 | 34 | 3 | 0 |
 | HEROMOTOCO.NS | 3.19% | 27 | 32 | 5 | 0 |
 | INFY.NS | 35.02% | 31 | 33 | 2 | 0 |
 | LT.NS | -30.88% | 24 | 27 | 3 | 0 |

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -153,5 +153,5 @@ def test_generate_per_stock_report(report_generator: ReportGenerator, sample_tra
     )
 
     assert "### Per-Stock Performance Breakdown" in report
-    assert "| STOCKA | 0.15% | 2 | 10 | 3 | 1 |" in report
+    assert "| STOCKA | 15.50% | 2 | 10 | 3 | 1 |" in report
     assert "| STOCKB | 0.00% | 0 | 0 | 0 | 0 |" in report


### PR DESCRIPTION
This commit addresses Task 30 by replacing the inefficient, multi-pass historical statistics calculation within the `Orchestrator` with a point-in-time correct, single-pass simulation.

Key changes:
- A new private method, `_pre_calculate_historical_performance`, has been added to `praxis_engine/core/orchestrator.py`. This method iterates through the data once, simulates trade signals, and calculates accumulating historical performance statistics (win rate, profit factor, sample size) without lookahead bias.
- The main `run_backtest` loop in the `Orchestrator` has been refactored. It now calls the new pre-calculation method once at the beginning of a stock's backtest.
- The O(1) lookup on the pre-calculated columns is now used to provide historical context to the `LLMAuditService`, replacing the previous inefficient approach.
- The old `_calculate_historical_stats_for_llm` method has been deleted.
- A new unit test, `test_pre_calculate_historical_performance`, has been added to `tests/test_orchestrator.py` to validate the correctness of the new single-pass logic.
- Existing tests for the `Orchestrator` have been updated to mock the new pre-calculation method, ensuring they remain isolated and focused on their specific logic. This involved fixing several test failures related to mock configurations and test data assumptions.