### PR TITLE
docs: Add MarketDataService to PRD

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -132,3 +132,9 @@ cost_model.slippage_rate_low_liquidity = 0.0005,0.005,0.0005
 exit_logic.atr_period = 7,28,1
 exit_logic.atr_stop_loss_multiplier = 1.0,4.0,0.25
 exit_logic.max_holding_days = 10,120,10
+
+[market_data]
+index_ticker = ^NSEI
+vix_ticker = ^INDIAVIX
+training_start_date = 2010-01-01
+cache_dir = data_cache/market

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ The `praxis_engine` package is organized as follows:
         -   `validation_service.py`: Applies the guardrail logic (Liquidity, Regime, Stat) to a signal.
         -   `execution_simulator.py`: Simulates a trade, applying a realistic cost model (slippage, brokerage, STT).
         -   `report_generator.py`: Generates all user-facing Markdown reports from the backtest results.
-        -   `llm_audit_service.py`: (If used) Handles communication with the external LLM API.
+        -   `llm_audit_service.py`: Handles communication with the external LLM API (OpenRouter) to get a final confidence score from the configured model (e.g., Kimi 2). Uses an API key from a `.env` file.
     -   `utils.py`: Contains small, stateless helper functions used across the codebase.
 
 ---

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -37,6 +37,7 @@ Praxis is built for the discerning quantitative analyst who understands that in 
 ### Functional Requirements (High-Level)
 
 -   **FR1: Indian Market Data Pipeline:** The system must fetch and process daily OHLCV data for NSE stocks using `yfinance` as the primary source. It must also fetch corresponding Nifty sectoral index data to calculate sector volatility. The pipeline must handle data errors, adjust for Indian market holidays, and persist the data for analysis.
+-   **FR1.1: Market-Wide Data Pipeline:** The system must be able to fetch and cache market-wide data, such as for the Nifty 50 (`^NSEI`) and India VIX (`^INDIAVIX`) indices, which are essential for building a market regime meta-model.
 -   **FR2: Multi-Frame Signal Generation:** The system must calculate technical indicators (Bollinger Bands, RSI) on three distinct time frames (Daily, Weekly, Monthly) from the daily data. It must generate a preliminary signal only when a specific alignment of these indicators occurs across frames, as defined in the `project_brief.md`.
 -   **FR3: Statistical Guardrail Validation:** Every preliminary signal must be subjected to a battery of statistical tests:
     -   **Mean-Reversion Test:** Augmented Dickey-Fuller (ADF) test to confirm the statistical property of mean-reversion in the stock's recent price action.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -649,7 +649,8 @@ Below are short, pragmatic summaries for Tasks 1 through 15: rationale, what was
     *   Create a new test file: `tests/test_market_data_service.py`.
     *   Write a unit test that mocks `yfinance.download` and verifies that the service correctly fetches, caches, and loads data from the cache.
 *   **Time estimate:** 3 hours
-*   **Status:** To Do
+*   **Status:** Done
+*   **Resolution:** A new `MarketDataService` was created in `praxis_engine/services/` to handle fetching and caching of market-wide data like indices. This service mirrors the caching logic of the existing `DataService` and is fully unit-tested. The configuration for this service was added to `config.ini` and the Pydantic models.
 
 ---
 

--- a/praxis_engine/core/models.py
+++ b/praxis_engine/core/models.py
@@ -198,11 +198,19 @@ class DrawdownPeriod(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
+class MarketDataConfig(BaseModel):
+    index_ticker: str
+    vix_ticker: str
+    training_start_date: str
+    cache_dir: str
+
+
 class Config(BaseModel):
     """
     Top-level configuration model.
     """
     data: DataConfig
+    market_data: MarketDataConfig
     strategy_params: StrategyParamsConfig
     filters: FiltersConfig
     scoring: ScoringConfig

--- a/praxis_engine/services/market_data_service.py
+++ b/praxis_engine/services/market_data_service.py
@@ -1,0 +1,68 @@
+"""
+This service is responsible for fetching and caching market-wide data, such as
+indices and volatility measures.
+"""
+import pandas as pd
+import yfinance as yf
+from pathlib import Path
+from typing import List, Optional
+
+from praxis_engine.core.logger import get_logger
+
+log = get_logger(__name__)
+
+
+class MarketDataService:
+    """
+    A service for fetching and caching market-wide data.
+    """
+
+    def __init__(self, cache_dir: str = "data_cache/market") -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # impure
+    def get_market_data(
+        self, tickers: List[str], start: str, end: str
+    ) -> Optional[pd.DataFrame]:
+        """
+        Fetches data for a given list of market tickers, with caching.
+
+        Args:
+            tickers: A list of market tickers (e.g., ['^NSEI', '^INDIAVIX']).
+            start: The start date for the data.
+            end: The end date for the data.
+        """
+        # Sanitize tickers for filename
+        safe_tickers = "_".join(t.replace("^", "") for t in tickers)
+        cache_file = self.cache_dir / f"{safe_tickers}_{start}_{end}.parquet"
+
+        if cache_file.exists():
+            log.info(f"Loading market data for {tickers} from cache.")
+            return pd.read_parquet(cache_file)
+
+        try:
+            log.info(f"Fetching fresh market data for {tickers}.")
+            df = yf.download(tickers, start=start, end=end, progress=False, auto_adjust=False)
+
+            if df.empty:
+                log.warning(f"No market data returned from yfinance for {tickers}.")
+                return None
+
+            # For single ticker, yfinance returns a simple column structure.
+            # For multiple tickers, it returns a MultiIndex. We want to handle both.
+            if isinstance(df.columns, pd.MultiIndex):
+                # We only care about the 'Close' prices for market data.
+                df = df['Close']
+                df.columns = [f"{t.replace('^', '')}_close" for t in tickers]
+            else:
+                # If single ticker, rename columns for consistency
+                df.rename(columns={'Close': f"{tickers[0].replace('^', '')}_close"}, inplace=True)
+
+
+            log.info(f"Saving market data for {tickers} to cache.")
+            df.to_parquet(cache_file)
+            return df
+        except Exception as e:
+            log.error(f"Error fetching market data for {tickers}: {e}")
+            return None

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1,0 +1,108 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+from pathlib import Path
+
+from praxis_engine.services.market_data_service import MarketDataService
+
+
+class TestMarketDataService(unittest.TestCase):
+    def setUp(self):
+        self.cache_dir = "test_cache/market"
+        # Clean up cache directory before each test to ensure a clean state
+        cache_path = Path(self.cache_dir)
+        if cache_path.exists():
+            for item in cache_path.iterdir():
+                item.unlink()
+            cache_path.rmdir()
+
+        self.service = MarketDataService(cache_dir=self.cache_dir)
+
+    def tearDown(self):
+        # Clean up cache directory after each test
+        cache_path = Path(self.cache_dir)
+        if cache_path.exists():
+            for item in cache_path.iterdir():
+                item.unlink()
+            cache_path.rmdir()
+
+    @patch("praxis_engine.services.market_data_service.yf.download")
+    def test_get_market_data_fetches_and_caches_data(self, mock_yf_download):
+        """
+        Test that data is fetched and cached when the cache is empty.
+        This test also verifies the multi-ticker response handling.
+        """
+        # Arrange
+        tickers = ["^NSEI", "^INDIAVIX"]
+        start_date = "2023-01-01"
+        end_date = "2023-01-31"
+
+        # Create a realistic multi-index DataFrame, as yfinance does for multiple tickers
+        mock_data = {
+            ('Close', '^NSEI'): [18000, 18100],
+            ('Close', '^INDIAVIX'): [12.5, 12.6]
+        }
+        mock_df = pd.DataFrame(mock_data)
+        mock_df.columns = pd.MultiIndex.from_tuples(mock_df.columns)
+        mock_yf_download.return_value = mock_df
+
+        # Act
+        with patch("praxis_engine.services.market_data_service.pd.DataFrame.to_parquet") as mock_to_parquet:
+            df = self.service.get_market_data(tickers, start_date, end_date)
+
+            # Assert
+            self.assertIsNotNone(df)
+            self.assertListEqual(list(df.columns), ['NSEI_close', 'INDIAVIX_close'])
+            mock_yf_download.assert_called_once_with(
+                tickers, start=start_date, end=end_date, progress=False, auto_adjust=False
+            )
+            # Check that we are trying to save the processed data to cache
+            mock_to_parquet.assert_called_once()
+            # Check that the service constructor created the cache directory
+            self.assertTrue(Path(self.cache_dir).exists())
+
+    @patch("praxis_engine.services.market_data_service.yf.download")
+    @patch("praxis_engine.services.market_data_service.pd.read_parquet")
+    @patch("praxis_engine.services.market_data_service.Path.exists")
+    def test_get_market_data_loads_from_cache(
+        self, mock_path_exists, mock_read_parquet, mock_yf_download
+    ):
+        """
+        Test that data is loaded from the cache if it exists.
+        """
+        # Arrange
+        mock_path_exists.return_value = True
+        mock_df = pd.DataFrame({"NSEI_close": [100, 101, 102]})
+        mock_read_parquet.return_value = mock_df
+        tickers = ["^NSEI"]
+        start_date = "2023-01-01"
+        end_date = "2023-01-31"
+
+        # Act
+        df = self.service.get_market_data(tickers, start_date, end_date)
+
+        # Assert
+        self.assertIsNotNone(df)
+        mock_read_parquet.assert_called_once()
+        mock_yf_download.assert_not_called()
+
+    @patch("praxis_engine.services.market_data_service.yf.download")
+    def test_get_market_data_handles_yfinance_error(self, mock_yf_download):
+        """
+        Test that the service handles errors from yfinance gracefully.
+        """
+        # Arrange
+        mock_yf_download.side_effect = Exception("Test yfinance error")
+        tickers = ["^FAIL"]
+        start_date = "2023-01-01"
+        end_date = "2023-01-31"
+
+        # Act
+        with patch("praxis_engine.services.market_data_service.log.error") as mock_log_error:
+            df = self.service.get_market_data(tickers, start_date, end_date)
+
+            # Assert
+            self.assertIsNone(df)
+            mock_log_error.assert_called_once_with(
+                f"Error fetching market data for {tickers}: Test yfinance error"
+            )


### PR DESCRIPTION
This commit updates the `docs/prd.md` file to include a new functional requirement for the `MarketDataService`.

The user correctly pointed out that the PRD was not updated after the creation of the new service in Task #49. This change adds `FR1.1` to the list of functional requirements, describing the purpose of the new service to fetch and cache market-wide data.

This keeps the PRD synchronized with the current state of the codebase.