### PR TITLE
feat: Implement feature engineering for market regime model

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -668,7 +668,8 @@ Below are short, pragmatic summaries for Tasks 1 through 15: rationale, what was
     *   Create a new test file: `tests/test_features.py`.
     *   Write unit tests for `calculate_market_features` with a sample input DataFrame and assert that the output features are calculated correctly.
 *   **Time estimate:** 2 hours
-*   **Status:** To Do
+*   **Status:** Done
+*   **Resolution:** A new module `praxis_engine/core/features.py` was created with the `calculate_market_features` function. The function correctly calculates `nifty_vs_200ma`, `vix_level`, and `vix_roc_10d` from the provided market data. Comprehensive unit tests were added in `tests/test_features.py` to validate the correctness of the calculations and error handling.
 
 ---
 
@@ -688,7 +689,8 @@ Below are short, pragmatic summaries for Tasks 1 through 15: rationale, what was
 *   **Tests to cover:**
     *   This is primarily tested by its integration in the following tasks. The manual run capability serves as a functional test.
 *   **Time estimate:** 4 hours
-*   **Status:** To Do
+*   **Status:** In Progress
+*   **Resolution:** A stub script `scripts/train_regime_model.py` has been created. It correctly loads the configuration, fetches market data using the `MarketDataService`, and calculates the required features using `calculate_market_features`. The actual model training and saving logic is yet to be implemented.
 
 ---
 

--- a/praxis_engine/core/features.py
+++ b/praxis_engine/core/features.py
@@ -1,0 +1,48 @@
+from typing import Dict
+
+import pandas as pd
+
+
+def calculate_market_features(
+    market_data: Dict[str, pd.DataFrame], nifty_ticker: str, vix_ticker: str
+) -> pd.DataFrame:
+    """
+    Calculates market-wide features for the regime model.
+
+    This function is pure and relies on the caller to provide the correct data.
+
+    Args:
+        market_data: A dictionary where keys are tickers and values are OHLCV DataFrames.
+                     Expected to contain data for Nifty 50 and India VIX.
+        nifty_ticker: The ticker symbol for the Nifty 50 index.
+        vix_ticker: The ticker symbol for the India VIX index.
+
+    Returns:
+        A DataFrame with a DatetimeIndex and columns for each calculated feature.
+    """
+    if nifty_ticker not in market_data:
+        raise ValueError(f"Nifty ticker '{nifty_ticker}' not found in market_data.")
+    if vix_ticker not in market_data:
+        raise ValueError(f"VIX ticker '{vix_ticker}' not found in market_data.")
+
+    nifty_df = market_data[nifty_ticker]
+    vix_df = market_data[vix_ticker]
+
+    # Feature 1: Nifty vs. 200-day Moving Average
+    nifty_close = nifty_df["Close"]
+    nifty_sma_200 = nifty_close.rolling(window=200, min_periods=200).mean()
+    nifty_vs_200ma = nifty_close / nifty_sma_200
+    nifty_vs_200ma.name = "nifty_vs_200ma"
+
+    # Feature 2: VIX Level
+    vix_level = vix_df["Close"].copy() # Use copy to avoid SettingWithCopyWarning
+    vix_level.name = "vix_level"
+
+    # Feature 3: VIX 10-day Rate of Change
+    vix_roc_10d = vix_level.pct_change(periods=10)
+    vix_roc_10d.name = "vix_roc_10d"
+
+    # Combine all features into a single DataFrame
+    features_df = pd.concat([nifty_vs_200ma, vix_level, vix_roc_10d], axis=1)
+
+    return features_df

--- a/scripts/train_regime_model.py
+++ b/scripts/train_regime_model.py
@@ -1,0 +1,56 @@
+# Add the project root to the python path to allow for absolute imports
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent.parent))
+
+import typer
+from rich import print
+
+from praxis_engine.services.config_service import load_config
+from praxis_engine.services.market_data_service import MarketDataService
+from praxis_engine.core.features import calculate_market_features
+
+app = typer.Typer()
+
+@app.command()
+def main(config_path: str = "config.ini"):
+    """
+    Trains and saves the market regime model.
+    This is currently a stub that demonstrates feature calculation.
+    """
+    print("Loading configuration...")
+    config = load_config(config_path)
+
+    print("Initializing services...")
+    market_data_service = MarketDataService(config.market_data.cache_dir)
+
+    print("Fetching market data...")
+    tickers = [config.market_data.index_ticker, config.market_data.vix_ticker]
+    market_data = market_data_service.get_market_data(
+        tickers=tickers,
+        start=config.market_data.training_start_date,
+        end=config.data.end_date,
+    )
+
+    if not market_data or config.market_data.index_ticker not in market_data or config.market_data.vix_ticker not in market_data:
+        print("[bold red]Failed to fetch all required market data. Exiting.[/bold red]")
+        raise typer.Exit(code=1)
+
+    print("Calculating features...")
+    features_df = calculate_market_features(
+        market_data=market_data,
+        nifty_ticker=config.market_data.index_ticker,
+        vix_ticker=config.market_data.vix_ticker,
+    )
+
+    print("\n[bold green]Feature calculation complete.[/bold green]")
+    print("Displaying head of features DataFrame:")
+    print(features_df.head())
+    print("\nDisplaying tail of features DataFrame:")
+    print(features_df.tail())
+
+    print("\n[bold yellow]NOTE: This is a stub script. Model training is not yet implemented.[/bold yellow]")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -18,6 +18,12 @@ end_date = "2023-01-01"
 sector_map = {"TEST.NS": "^TESTINDEX"}
 workers = 4
 
+[market_data]
+index_ticker = "^NSEI"
+vix_ticker = "^INDIAVIX"
+training_start_date = "2010-01-01"
+cache_dir = "test_cache/market"
+
 [strategy_params]
 bb_length = 10
 bb_std = 1.5
@@ -101,6 +107,12 @@ start_date = "2022-01-01"
 end_date = "2023-01-01"
 sector_map = {"TEST.NS": "^TESTINDEX"}
 
+[market_data]
+index_ticker = "^NSEI"
+vix_ticker = "^INDIAVIX"
+training_start_date = "2010-01-01"
+cache_dir = "test_cache/market"
+
 [strategy_params]
 bb_length = 10
 bb_std = 1.5
@@ -178,6 +190,12 @@ stocks_to_backtest = ["TEST.NS"]
 start_date = "2022-01-01"
 end_date = "2023-01-01"
 sector_map = {"TEST.NS": "^TESTINDEX"}
+
+[market_data]
+index_ticker = "^NSEI"
+vix_ticker = "^INDIAVIX"
+training_start_date = "2010-01-01"
+cache_dir = "test_cache/market"
 
 [strategy_params]
 bb_length = 10

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,82 @@
+import pandas as pd
+import pytest
+import numpy as np
+
+from praxis_engine.core.features import calculate_market_features
+
+
+@pytest.fixture
+def sample_market_data():
+    """Creates a sample market data dictionary for testing."""
+    dates = pd.to_datetime(pd.date_range(start="2023-01-01", periods=210, freq="D"))
+
+    # Nifty data: 200 days of 100, then 10 days of 110
+    nifty_prices = [100.0] * 200 + [110.0] * 10
+    nifty_df = pd.DataFrame({"Close": nifty_prices}, index=dates)
+
+    # VIX data: simple increasing series
+    vix_prices = np.arange(10, 10 + len(dates), dtype=float)
+    vix_df = pd.DataFrame({"Close": vix_prices}, index=dates)
+
+    return {
+        "^NSEI": nifty_df,
+        "^INDIAVIX": vix_df,
+    }
+
+
+def test_calculate_market_features_success(sample_market_data):
+    """
+    Tests successful calculation of market features.
+    """
+    nifty_ticker = "^NSEI"
+    vix_ticker = "^INDIAVIX"
+
+    features_df = calculate_market_features(sample_market_data, nifty_ticker, vix_ticker)
+
+    # --- Assertions ---
+    assert isinstance(features_df, pd.DataFrame)
+    assert list(features_df.columns) == ["nifty_vs_200ma", "vix_level", "vix_roc_10d"]
+    assert len(features_df) == 210
+
+    # Check for NaNs at the beginning due to rolling windows
+    assert features_df["nifty_vs_200ma"].iloc[:199].isnull().all()
+    assert not features_df["nifty_vs_200ma"].iloc[199:].isnull().any()
+    assert features_df["vix_roc_10d"].iloc[:10].isnull().all()
+    assert not features_df["vix_roc_10d"].iloc[10:].isnull().any()
+
+    # --- Check specific calculated values for the last day ---
+    last_day = features_df.index[-1]
+
+    # Expected nifty_vs_200ma for the last day
+    # Window for index 209 includes indices 10 through 209.
+    # This window has 190 days of 100.0 and 10 days of 110.0.
+    expected_sma = ((190 * 100.0) + (10 * 110.0)) / 200.0  # 100.5
+    expected_nifty_ratio = 110.0 / expected_sma
+    assert features_df.loc[last_day, "nifty_vs_200ma"] == pytest.approx(expected_nifty_ratio)
+
+    # Expected vix_level for the last day
+    expected_vix_level = 10.0 + 209.0
+    assert features_df.loc[last_day, "vix_level"] == pytest.approx(expected_vix_level)
+
+    # Expected vix_roc_10d for the last day
+    # price[209] = 10 + 209 = 219. price[199] = 10 + 199 = 209.
+    vix_today = 10.0 + 209.0
+    vix_10_days_ago = 10.0 + 199.0
+    expected_vix_roc = (vix_today - vix_10_days_ago) / vix_10_days_ago
+    assert features_df.loc[last_day, "vix_roc_10d"] == pytest.approx(expected_vix_roc)
+
+
+def test_calculate_market_features_missing_nifty(sample_market_data):
+    """
+    Tests that a ValueError is raised if the Nifty ticker is not in the data.
+    """
+    with pytest.raises(ValueError, match="Nifty ticker 'MISSING_NIFTY' not found in market_data."):
+        calculate_market_features(sample_market_data, "MISSING_NIFTY", "^INDIAVIX")
+
+
+def test_calculate_market_features_missing_vix(sample_market_data):
+    """
+    Tests that a ValueError is raised if the VIX ticker is not in the data.
+    """
+    with pytest.raises(ValueError, match="VIX ticker 'MISSING_VIX' not found in market_data."):
+        calculate_market_features(sample_market_data, "^NSEI", "MISSING_VIX")

--- a/tests/test_llm_optional.py
+++ b/tests/test_llm_optional.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import datetime
-from praxis_engine.core.models import Config, DataConfig, StrategyParamsConfig, FiltersConfig, ScoringConfig, SignalLogicConfig, LLMConfig, CostModelConfig, ExitLogicConfig
+from praxis_engine.core.models import Config, DataConfig, StrategyParamsConfig, FiltersConfig, ScoringConfig, SignalLogicConfig, LLMConfig, CostModelConfig, ExitLogicConfig, MarketDataConfig
 from praxis_engine.core.orchestrator import Orchestrator
 
 
@@ -73,8 +73,16 @@ def make_minimal_config(tmp_cache_dir: str) -> Config:
         reward_risk_ratio=1.75,
     )
 
+    market_data = MarketDataConfig(
+        index_ticker="^NSEI",
+        vix_ticker="^INDIAVIX",
+        training_start_date="2010-01-01",
+        cache_dir=tmp_cache_dir,
+    )
+
     return Config(
         data=data,
+        market_data=market_data,
         strategy_params=strategy_params,
         filters=filters,
         scoring=scoring,

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, call
 import pandas as pd
 from pathlib import Path
 
@@ -14,7 +14,8 @@ class TestMarketDataService(unittest.TestCase):
         if cache_path.exists():
             for item in cache_path.iterdir():
                 item.unlink()
-            cache_path.rmdir()
+            if not any(cache_path.iterdir()):
+                cache_path.rmdir()
 
         self.service = MarketDataService(cache_dir=self.cache_dir)
 
@@ -24,72 +25,72 @@ class TestMarketDataService(unittest.TestCase):
         if cache_path.exists():
             for item in cache_path.iterdir():
                 item.unlink()
-            cache_path.rmdir()
+            if not any(cache_path.iterdir()):
+                cache_path.rmdir()
 
     @patch("praxis_engine.services.market_data_service.yf.download")
     def test_get_market_data_fetches_and_caches_data(self, mock_yf_download):
         """
         Test that data is fetched and cached when the cache is empty.
-        This test also verifies the multi-ticker response handling.
         """
         # Arrange
         tickers = ["^NSEI", "^INDIAVIX"]
         start_date = "2023-01-01"
         end_date = "2023-01-31"
 
-        # Create a realistic multi-index DataFrame, as yfinance does for multiple tickers
-        mock_data = {
-            ('Close', '^NSEI'): [18000, 18100],
-            ('Close', '^INDIAVIX'): [12.5, 12.6]
-        }
-        mock_df = pd.DataFrame(mock_data)
-        mock_df.columns = pd.MultiIndex.from_tuples(mock_df.columns)
-        mock_yf_download.return_value = mock_df
+        mock_nse_df = pd.DataFrame({'Close': [18000, 18100]})
+        mock_vix_df = pd.DataFrame({'Close': [12.5, 12.6]})
+        mock_yf_download.side_effect = [mock_nse_df, mock_vix_df]
 
         # Act
         with patch("praxis_engine.services.market_data_service.pd.DataFrame.to_parquet") as mock_to_parquet:
-            df = self.service.get_market_data(tickers, start_date, end_date)
+            data_dict = self.service.get_market_data(tickers, start_date, end_date)
 
             # Assert
-            self.assertIsNotNone(df)
-            self.assertListEqual(list(df.columns), ['NSEI_close', 'INDIAVIX_close'])
-            mock_yf_download.assert_called_once_with(
-                tickers, start=start_date, end=end_date, progress=False, auto_adjust=False
-            )
-            # Check that we are trying to save the processed data to cache
-            mock_to_parquet.assert_called_once()
-            # Check that the service constructor created the cache directory
-            self.assertTrue(Path(self.cache_dir).exists())
+            self.assertIsInstance(data_dict, dict)
+            self.assertIn("^NSEI", data_dict)
+            self.assertIn("^INDIAVIX", data_dict)
+            pd.testing.assert_frame_equal(data_dict["^NSEI"], mock_nse_df)
+            pd.testing.assert_frame_equal(data_dict["^INDIAVIX"], mock_vix_df)
+
+            # Check that yf.download was called for each ticker
+            self.assertEqual(mock_yf_download.call_count, 2)
+            mock_yf_download.assert_has_calls([
+                call("^NSEI", start=start_date, end=end_date, progress=False, auto_adjust=False),
+                call("^INDIAVIX", start=start_date, end=end_date, progress=False, auto_adjust=False)
+            ], any_order=True)
+
+            # Check that we are trying to save each df to cache
+            self.assertEqual(mock_to_parquet.call_count, 2)
 
     @patch("praxis_engine.services.market_data_service.yf.download")
     @patch("praxis_engine.services.market_data_service.pd.read_parquet")
-    @patch("praxis_engine.services.market_data_service.Path.exists")
-    def test_get_market_data_loads_from_cache(
-        self, mock_path_exists, mock_read_parquet, mock_yf_download
-    ):
+    def test_get_market_data_loads_from_cache(self, mock_read_parquet, mock_yf_download):
         """
         Test that data is loaded from the cache if it exists.
         """
         # Arrange
-        mock_path_exists.return_value = True
-        mock_df = pd.DataFrame({"NSEI_close": [100, 101, 102]})
-        mock_read_parquet.return_value = mock_df
         tickers = ["^NSEI"]
         start_date = "2023-01-01"
         end_date = "2023-01-31"
 
-        # Act
-        df = self.service.get_market_data(tickers, start_date, end_date)
+        mock_df = pd.DataFrame({"Close": [100, 101, 102]})
+        mock_read_parquet.return_value = mock_df
 
-        # Assert
-        self.assertIsNotNone(df)
-        mock_read_parquet.assert_called_once()
-        mock_yf_download.assert_not_called()
+        with patch("praxis_engine.services.market_data_service.Path.exists", return_value=True):
+            # Act
+            data_dict = self.service.get_market_data(tickers, start_date, end_date)
+
+            # Assert
+            self.assertIn("^NSEI", data_dict)
+            pd.testing.assert_frame_equal(data_dict["^NSEI"], mock_df)
+            mock_read_parquet.assert_called_once()
+            mock_yf_download.assert_not_called()
 
     @patch("praxis_engine.services.market_data_service.yf.download")
     def test_get_market_data_handles_yfinance_error(self, mock_yf_download):
         """
-        Test that the service handles errors from yfinance gracefully.
+        Test that the service handles errors from yfinance gracefully and returns an empty dict.
         """
         # Arrange
         mock_yf_download.side_effect = Exception("Test yfinance error")
@@ -99,10 +100,11 @@ class TestMarketDataService(unittest.TestCase):
 
         # Act
         with patch("praxis_engine.services.market_data_service.log.error") as mock_log_error:
-            df = self.service.get_market_data(tickers, start_date, end_date)
+            data_dict = self.service.get_market_data(tickers, start_date, end_date)
 
             # Assert
-            self.assertIsNone(df)
+            self.assertIsInstance(data_dict, dict)
+            self.assertEqual(len(data_dict), 0)
             mock_log_error.assert_called_once_with(
-                f"Error fetching market data for {tickers}: Test yfinance error"
+                f"Error fetching market data for {tickers[0]}: Test yfinance error"
             )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -32,6 +32,12 @@ start_date = "2022-01-01"
 end_date = "2023-01-01"
 sector_map = {"TEST.NS": "^TESTINDEX"}
 
+[market_data]
+index_ticker = "^NSEI"
+vix_ticker = "^INDIAVIX"
+training_start_date = "2010-01-01"
+cache_dir = "test_cache/market"
+
 [strategy_params]
 bb_length = 20
 bb_std = 2.0


### PR DESCRIPTION
This commit implements Task 50 and a stub for Task 51 from docs/tasks.md.

- Creates a new module `praxis_engine/core/features.py` with a pure function `calculate_market_features` to compute market-wide features (nifty_vs_200ma, vix_level, vix_roc_10d).
- Adds comprehensive unit tests for the new feature calculation module.
- Refactors `MarketDataService` to return a dictionary of DataFrames, making its API more robust and its caching more granular. Updates its tests accordingly.
- Creates a new script `scripts/train_regime_model.py` to demonstrate the usage of the new feature engineering pipeline.
- Updates test configurations across the suite to include the new `[market_data]` section, fixing several test failures.
- Updates `docs/tasks.md` to reflect the completion of Task 50 and the partial implementation of Task 51.