### PR TITLE
feat(regime): Implement and test regime model training script

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -689,8 +689,8 @@ Below are short, pragmatic summaries for Tasks 1 through 15: rationale, what was
 *   **Tests to cover:**
     *   This is primarily tested by its integration in the following tasks. The manual run capability serves as a functional test.
 *   **Time estimate:** 4 hours
-*   **Status:** Stubbed - Not Implemented
-*   **Resolution (Reviewer):** The script `scripts/train_regime_model.py` exists but is a stub. It correctly fetches data and calculates features but explicitly states that model training and saving are not implemented. The core logic of this task remains incomplete.
+*   **Status:** Done
+*   **Resolution:** Re-implemented the `scripts/train_regime_model.py` script to be robust and configurable. Added the `[regime_model]` section to `config.ini` and updated the Pydantic models accordingly. Added missing dependencies to `requirements.txt`. Added a functional test for the script and fixed all related test failures in the suite. The script now runs successfully and saves a trained model.
 
 ---
 

--- a/praxis_engine/core/models.py
+++ b/praxis_engine/core/models.py
@@ -204,6 +204,10 @@ class MarketDataConfig(BaseModel):
     training_start_date: str
     cache_dir: str
 
+class RegimeModelConfig(BaseModel):
+    model_path: str
+    volatility_threshold_percentile: float = Field(..., ge=0, le=1)
+
 
 class Config(BaseModel):
     """
@@ -211,6 +215,7 @@ class Config(BaseModel):
     """
     data: DataConfig
     market_data: MarketDataConfig
+    regime_model: RegimeModelConfig
     strategy_params: StrategyParamsConfig
     filters: FiltersConfig
     scoring: ScoringConfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ pyarrow
 openai
 tqdm
 numba
+scikit-learn
+joblib
 
 # Development & Testing
 pytest

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -24,6 +24,10 @@ vix_ticker = "^INDIAVIX"
 training_start_date = "2010-01-01"
 cache_dir = "test_cache/market"
 
+[regime_model]
+model_path = "results/regime_model.joblib"
+volatility_threshold_percentile = 0.75
+
 [strategy_params]
 bb_length = 10
 bb_std = 1.5
@@ -113,6 +117,10 @@ vix_ticker = "^INDIAVIX"
 training_start_date = "2010-01-01"
 cache_dir = "test_cache/market"
 
+[regime_model]
+model_path = "results/regime_model.joblib"
+volatility_threshold_percentile = 0.75
+
 [strategy_params]
 bb_length = 10
 bb_std = 1.5
@@ -196,6 +204,10 @@ index_ticker = "^NSEI"
 vix_ticker = "^INDIAVIX"
 training_start_date = "2010-01-01"
 cache_dir = "test_cache/market"
+
+[regime_model]
+model_path = "results/regime_model.joblib"
+volatility_threshold_percentile = 0.75
 
 [strategy_params]
 bb_length = 10
@@ -284,6 +296,16 @@ stocks_to_backtest = ["TEST.NS"]
 start_date = "2022-01-01"
 end_date = "2023-01-01"
 sector_map = {"TEST.NS": "^TESTINDEX"}
+
+[market_data]
+index_ticker = "^NSEI"
+vix_ticker = "^INDIAVIX"
+training_start_date = "2010-01-01"
+cache_dir = "test_cache/market"
+
+[regime_model]
+model_path = "results/regime_model.joblib"
+volatility_threshold_percentile = 0.75
 
 [strategy_params]
 bb_length = "not-an-int"  # Invalid type

--- a/tests/test_llm_optional.py
+++ b/tests/test_llm_optional.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import datetime
-from praxis_engine.core.models import Config, DataConfig, StrategyParamsConfig, FiltersConfig, ScoringConfig, SignalLogicConfig, LLMConfig, CostModelConfig, ExitLogicConfig, MarketDataConfig
+from praxis_engine.core.models import Config, DataConfig, StrategyParamsConfig, FiltersConfig, ScoringConfig, SignalLogicConfig, LLMConfig, CostModelConfig, ExitLogicConfig, MarketDataConfig, RegimeModelConfig
 from praxis_engine.core.orchestrator import Orchestrator
 
 
@@ -80,9 +80,15 @@ def make_minimal_config(tmp_cache_dir: str) -> Config:
         cache_dir=tmp_cache_dir,
     )
 
+    regime_model = RegimeModelConfig(
+        model_path="results/regime_model.joblib",
+        volatility_threshold_percentile=0.75,
+    )
+
     return Config(
         data=data,
         market_data=market_data,
+        regime_model=regime_model,
         strategy_params=strategy_params,
         filters=filters,
         scoring=scoring,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -38,6 +38,10 @@ vix_ticker = "^INDIAVIX"
 training_start_date = "2010-01-01"
 cache_dir = "test_cache/market"
 
+[regime_model]
+model_path = "results/regime_model.joblib"
+volatility_threshold_percentile = 0.75
+
 [strategy_params]
 bb_length = 20
 bb_std = 2.0

--- a/tests/test_regime_model_service.py
+++ b/tests/test_regime_model_service.py
@@ -64,10 +64,10 @@ class TestRegimeModelService(unittest.TestCase):
         # Arrange
         # Use a real, simple model that can be pickled
         real_model = LogisticRegression()
-        # Train it on dummy data so it can predict
-        real_model.fit([[1, 2], [3, 4]], [0, 1])
-
         feature_cols = ["f1", "f2"]
+        # Train it on a dummy DataFrame so it has feature names
+        train_df = pd.DataFrame([[1, 2], [3, 4]], columns=feature_cols)
+        real_model.fit(train_df, [0, 1])
 
         model_data = {"model": real_model, "feature_columns": feature_cols}
         joblib.dump(model_data, self.test_model_path)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).parent.parent))
+
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, MagicMock
+
+from scripts.train_regime_model import train_and_save_model
+from praxis_engine.core.models import Config, MarketDataConfig, DataConfig, RegimeModelConfig
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> Config:
+    """Provides a mock Config object for testing."""
+    config = MagicMock(spec=Config)
+
+    config.market_data = MagicMock(spec=MarketDataConfig)
+    config.market_data.cache_dir = str(tmp_path)
+    config.market_data.index_ticker = "^NSEI"
+    config.market_data.vix_ticker = "^INDIAVIX"
+    config.market_data.training_start_date = "2020-01-01"
+
+    config.data = MagicMock(spec=DataConfig)
+    config.data.end_date = "2021-01-01"
+
+    config.regime_model = MagicMock(spec=RegimeModelConfig)
+    config.regime_model.model_path = str(tmp_path / "regime_model.joblib")
+    config.regime_model.volatility_threshold_percentile = 0.75
+
+    return config
+
+def create_dummy_market_data() -> dict[str, pd.DataFrame]:
+    """Creates a dummy market data dictionary for mocking."""
+    dates = pd.to_datetime(pd.date_range(start="2020-01-01", end="2021-01-01", freq="D"))
+    close_prices = 12000 + np.random.randn(len(dates)).cumsum()
+    nifty_data = pd.DataFrame({"Close": close_prices}, index=dates)
+    vix_data = pd.DataFrame({"Close": 15.5}, index=dates)
+    return {"^NSEI": nifty_data, "^INDIAVIX": vix_data}
+
+def create_dummy_features() -> pd.DataFrame:
+    """Creates a dummy features DataFrame for mocking."""
+    dates = pd.to_datetime(pd.date_range(start="2020-01-01", end="2021-01-01", freq="D"))
+    return pd.DataFrame({"nifty_vs_200ma": 1.05}, index=dates)
+
+@patch('scripts.train_regime_model.calculate_market_features', return_value=create_dummy_features())
+@patch('scripts.train_regime_model.MarketDataService.get_market_data', return_value=create_dummy_market_data())
+def test_train_and_save_model_creates_file(
+    mock_get_market_data: MagicMock,
+    mock_calculate_features: MagicMock,
+    mock_config: Config
+):
+    """
+    Tests that the train_and_save_model function runs successfully
+    and creates a model file in the specified directory.
+    """
+    # Act
+    success = train_and_save_model(mock_config)
+
+    # Assert
+    assert success is True
+
+    mock_get_market_data.assert_called_once()
+    mock_calculate_features.assert_called_once()
+
+    model_path = Path(mock_config.regime_model.model_path)
+    assert model_path.exists()
+    assert model_path.is_file()


### PR DESCRIPTION
This commit completes Task #51 by implementing and verifying the market regime model training script.

The `scripts/train_regime_model.py` script was re-implemented to be robust and configurable. It now trains a logistic regression model on market-wide features to classify market regimes and saves the model to a file specified in the configuration.

Key changes:
- Added `scikit-learn` and `joblib` to `requirements.txt`.
- Added a new `[regime_model]` section to `config.ini` for configurability.
- Updated the Pydantic `Config` model in `praxis_engine/core/models.py` to include the new `RegimeModelConfig`.
- Added a new functional test in `tests/test_scripts.py` to ensure the training script works correctly.
- Fixed all related `ValidationError`s in the existing test suite caused by the config change.
- Updated `docs/tasks.md` to mark the task as complete.